### PR TITLE
Sumcheck circuit

### DIFF
--- a/src/gadgets/mod.rs
+++ b/src/gadgets/mod.rs
@@ -2,4 +2,5 @@
 pub mod ecc;
 pub(crate) mod nonnative;
 pub(crate) mod r1cs;
+pub(crate) mod sumcheck;
 pub(crate) mod utils;

--- a/src/gadgets/sumcheck.rs
+++ b/src/gadgets/sumcheck.rs
@@ -1,0 +1,116 @@
+#![allow(unused)]
+use crate::traits::Group;
+use bellperson::{
+  gadgets::{
+    boolean::{AllocatedBit, Boolean},
+    num::{AllocatedNum, Num},
+    Assignment,
+  },
+  ConstraintSystem, LinearCombination, SynthesisError,
+};
+use ff::{Field, PrimeField, PrimeFieldBits};
+
+// method compatible with src/spartan/sumcheck.rs > UniPoly::evaluate()
+pub fn uni_evaluate<Scalar, CS>(
+  mut cs: CS,
+  coeffs: Vec<AllocatedNum<Scalar>>,
+  r: AllocatedNum<Scalar>,
+) -> Result<AllocatedNum<Scalar>, SynthesisError>
+where
+  Scalar: PrimeField + PrimeFieldBits,
+  CS: ConstraintSystem<Scalar>,
+{
+  let mut eval_alloc: AllocatedNum<Scalar> =
+    AllocatedNum::<Scalar>::alloc(&mut cs, || Ok(Scalar::ZERO))?;
+  let mut eval: Num<Scalar> = Num::<Scalar>::from(eval_alloc);
+
+  let mut curr: AllocatedNum<Scalar> = AllocatedNum::<Scalar>::alloc(&mut cs, || Ok(Scalar::ONE))?;
+  for (i, coeff) in coeffs.iter().enumerate() {
+    eval = eval.add(&Num::<Scalar>::from(
+      curr.mul(cs.namespace(|| format!("mul {}", i)), &coeff)?,
+    ));
+    curr = curr.mul(cs.namespace(|| format!("mul2 {}", i)), &r)?;
+  }
+  let allocated_eval: AllocatedNum<Scalar> =
+    AllocatedNum::<Scalar>::alloc(&mut cs, || Ok(eval.get_value().unwrap()))?;
+
+  Ok(allocated_eval)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::bellperson::{
+    r1cs::{NovaShape, NovaWitness},
+    {shape_cs::ShapeCS, solver::SatisfyingAssignment},
+  };
+  use crate::spartan::sumcheck::UniPoly;
+  use pasta_curves::{
+    arithmetic::CurveAffine,
+    group::{Curve, Group},
+    pallas,
+    pallas::Scalar,
+    vesta,
+  };
+
+  fn synthetize_uni_evaluate<Scalar, CS>(
+    mut cs: CS,
+    coeffs: Vec<Scalar>,
+    r: Scalar,
+  ) -> AllocatedNum<Scalar>
+  where
+    Scalar: PrimeField + PrimeFieldBits,
+    CS: ConstraintSystem<Scalar>,
+  {
+    // prepare inputs
+    let r_var = AllocatedNum::<Scalar>::alloc(cs.namespace(|| "alloc r"), || Ok(r)).unwrap();
+    let mut coeffs_var: Vec<AllocatedNum<Scalar>> = Vec::new();
+    for (i, coeff) in coeffs.iter().enumerate() {
+      coeffs_var.push(
+        AllocatedNum::<Scalar>::alloc(cs.namespace(|| format!("alloc coeffs {}", i)), || {
+          Ok(*coeff)
+        })
+        .unwrap(),
+      );
+    }
+
+    // define inputs
+    // let _ = r_var.inputize(cs.namespace(|| "Input r"));
+    // for (i, coeff) in coeffs_var.iter().enumerate() {
+    //   let _ = coeff.inputize(cs.namespace(|| format!("Input coeffs {}", i)));
+    // }
+
+    // evaluate in-circuit (synthetize)
+    let res = uni_evaluate(cs.namespace(|| "uni_evaluate"), coeffs_var, r_var).unwrap();
+    // let _ = res.inputize(cs.namespace(|| "Output res"));
+
+    res
+  }
+
+  #[test]
+  fn test_uni_evaluate() {
+    let evals = vec![
+      Scalar::from(1_u64),
+      Scalar::from(2_u64),
+      Scalar::from(3_u64),
+    ];
+    let p = UniPoly::<pallas::Point>::from_evals(&evals);
+    let r = Scalar::from(5_u64);
+
+    // let's test it against the CS
+    let mut cs: ShapeCS<pallas::Point> = ShapeCS::new();
+    let _ = synthetize_uni_evaluate(&mut cs, p.coeffs.clone(), r);
+
+    println!("Number of constraints: {}", cs.num_constraints());
+
+    let (shape, ck) = cs.r1cs_shape();
+
+    let mut cs: SatisfyingAssignment<pallas::Point> = SatisfyingAssignment::new();
+    let res = synthetize_uni_evaluate(&mut cs, p.coeffs.clone(), r);
+    println!("circ res {:?}", res.get_value());
+    assert_eq!(res.get_value().unwrap(), p.evaluate(&r));
+
+    let (inst, witness) = cs.r1cs_instance_and_witness(&shape, &ck).unwrap();
+    assert!(shape.is_sat(&ck, &inst, &witness).is_ok());
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
   future_incompatible,
   nonstandard_style,
   rust_2018_idioms,
-  // missing_docs
+  missing_docs
 )]
 #![allow(non_snake_case)]
 #![allow(clippy::type_complexity)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
   future_incompatible,
   nonstandard_style,
   rust_2018_idioms,
-  missing_docs
+  // missing_docs
 )]
 #![allow(non_snake_case)]
 #![allow(clippy::type_complexity)]

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -8,7 +8,7 @@ pub(crate) mod math;
 pub(crate) mod polynomial;
 pub mod ppsnark;
 pub mod snark;
-mod sumcheck;
+pub mod sumcheck;
 
 use crate::{traits::Group, Commitment};
 use ff::Field;

--- a/src/spartan/polynomial.rs
+++ b/src/spartan/polynomial.rs
@@ -61,7 +61,7 @@ impl<Scalar: PrimeField> EqPolynomial<Scalar> {
   }
 }
 
-/// A multilinear extension of a polynomial $Z(\cdot)$, donate it as $\tilde{Z}(x_1, ..., x_m)$
+/// A multilinear extension of a polynomial $Z(\cdot)$, denote it as $\tilde{Z}(x_1, ..., x_m)$
 /// where the degree of each variable is at most one.
 ///
 /// This is the dense representation of a multilinear poynomial.

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -337,7 +337,7 @@ impl<G: Group> SumcheckProof<G> {
 // ax^3 + bx^2 + cx + d stored as vec![a,b,c,d]
 #[derive(Debug)]
 pub struct UniPoly<G: Group> {
-  pub coeffs: Vec<G::Scalar>,
+  coeffs: Vec<G::Scalar>,
 }
 
 // ax^2 + bx + c stored as vec![a,c]
@@ -380,6 +380,10 @@ impl<G: Group> UniPoly<G> {
     };
 
     UniPoly { coeffs }
+  }
+
+  pub fn get_coeffs(&self) -> Vec<G::Scalar> {
+    self.coeffs.clone()
   }
 
   pub fn degree(&self) -> usize {

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -292,7 +292,7 @@ impl<G: Group> SumcheckProof<G> {
 // ax^3 + bx^2 + cx + d stored as vec![a,b,c,d]
 #[derive(Debug)]
 pub struct UniPoly<G: Group> {
-  coeffs: Vec<G::Scalar>,
+  pub coeffs: Vec<G::Scalar>,
 }
 
 // ax^2 + bx + c stored as vec![a,c]

--- a/src/spartan/sumcheck.rs
+++ b/src/spartan/sumcheck.rs
@@ -451,7 +451,7 @@ mod tests {
 
   #[test]
   fn test_prove() {
-    // g(X_0, X_1, X_2) = 2 * X_0^3 + X_0 * X_2 + X_1 X_2
+    // g(X_0, X_1, X_2) = 2 X_0^3 + X_0 X_2 + X_1 X_2
     let Z = vec![
       Fq::zero(),
       Fq::zero(),


### PR DESCRIPTION
Add SumCheck verification r1cs-bellperson gadget.

This PR:
- add gadget for univariate polynomial evaluation
- add gadget for sumcheck verification
- add sumcheck prover for a single multivariate polynomial on Spartan submodule
  - this is used in the gadget test, but in the future can be used by the multifolding prover

To do after this PR:
- add gadget for the transcript compatible with the rust-native transcript from Nova codebase ( #27 )
- ask for some bellman/bellperson knowledgable person for input on the gadgets constraints handling

once the transcript gadget is ready, we can then compare the number of constraints with the arkworks sumcheck-verify gadget number of constraints.

resolves #25 