### PR TITLE
fix: Address all Clippy suggestions/lints

### DIFF
--- a/src/ccs/lcccs.rs
+++ b/src/ccs/lcccs.rs
@@ -86,7 +86,7 @@ impl<G: Group> LCCCS<G> {
       // Sanity check
       assert_eq!(z_mle.get_num_vars(), self.ccs.s_prime);
 
-      let sum_Mz = compute_sum_Mz::<G>(&M_j, &z_mle);
+      let sum_Mz = compute_sum_Mz::<G>(M_j, &z_mle);
       let sum_Mz_virtual = VirtualPolynomial::new_from_mle(&Arc::new(sum_Mz), G::Scalar::ONE);
       let L_j_x = sum_Mz_virtual.build_f_hat(&self.r_x).unwrap();
       vec_L_j_x.push(L_j_x);
@@ -127,7 +127,7 @@ mod tests {
 
   #[test]
   /// Test linearized CCCS v_j against the L_j(x)
-  fn test_lcccs_v_j() -> () {
+  fn test_lcccs_v_j() {
     let mut rng = OsRng;
 
     // Gen test vectors & artifacts
@@ -143,7 +143,6 @@ mod tests {
 
     for (v_i, L_j_x) in lcccs.v.into_iter().zip(vec_L_j_x) {
       let sum_L_j_x = BooleanHypercube::new(ccs.s)
-        .into_iter()
         .map(|y| L_j_x.evaluate(&y).unwrap())
         .fold(Fq::ZERO, |acc, result| acc + result);
       assert_eq!(v_i, sum_L_j_x);
@@ -152,7 +151,7 @@ mod tests {
 
   /// Given a bad z, check that the v_j should not match with the L_j(x)
   #[test]
-  fn test_bad_v_j() -> () {
+  fn test_bad_v_j() {
     let mut rng = OsRng;
 
     // Gen test vectors & artifacts
@@ -180,7 +179,6 @@ mod tests {
     let mut satisfied = true;
     for (v_i, L_j_x) in lcccs.v.into_iter().zip(vec_L_j_x) {
       let sum_L_j_x = BooleanHypercube::new(ccs.s)
-        .into_iter()
         .map(|y| L_j_x.evaluate(&y).unwrap())
         .fold(Fq::ZERO, |acc, result| acc + result);
       if v_i != sum_L_j_x {
@@ -188,6 +186,6 @@ mod tests {
       }
     }
 
-    assert_eq!(satisfied, false);
+    assert!(!satisfied);
   }
 }

--- a/src/ccs/multifolding.rs
+++ b/src/ccs/multifolding.rs
@@ -242,17 +242,17 @@ mod tests {
 
     // evaluate g(x) over x \in {0,1}^s
     let mut g_on_bhc = Fq::zero();
-    for x in BooleanHypercube::new(ccs.s).into_iter() {
+    for x in BooleanHypercube::new(ccs.s) {
       g_on_bhc += g.evaluate(&x).unwrap();
     }
 
     // evaluate sum_{j \in [t]} (gamma^j * Lj(x)) over x \in {0,1}^s
     let mut sum_Lj_on_bhc = Fq::zero();
     let vec_L = lcccs_instance.compute_Ls(&z1);
-    for x in BooleanHypercube::new(ccs.s).into_iter() {
-      for j in 0..vec_L.len() {
+    for x in BooleanHypercube::new(ccs.s) {
+      for (j, coeff) in vec_L.iter().enumerate() {
         let gamma_j = gamma.pow([j as u64]);
-        sum_Lj_on_bhc += vec_L[j].evaluate(&x).unwrap() * gamma_j;
+        sum_Lj_on_bhc += coeff.evaluate(&x).unwrap() * gamma_j;
       }
     }
 
@@ -269,7 +269,7 @@ mod tests {
   }
 
   #[test]
-  fn test_compute_sigmas_and_thetas() -> () {
+  fn test_compute_sigmas_and_thetas() {
     let z1 = CCSShape::<Ep>::get_test_z(3);
     let z2 = CCSShape::<Ep>::get_test_z(4);
 
@@ -300,16 +300,16 @@ mod tests {
     {
       // evaluate g(x) over x \in {0,1}^s
       let mut g_on_bhc = Fq::zero();
-      for x in BooleanHypercube::new(ccs.s).into_iter() {
+      for x in BooleanHypercube::new(ccs.s) {
         g_on_bhc += g.evaluate(&x).unwrap();
       }
       // evaluate sum_{j \in [t]} (gamma^j * Lj(x)) over x \in {0,1}^s
       let mut sum_Lj_on_bhc = Fq::zero();
       let vec_L = lcccs_instance.compute_Ls(&z1);
-      for x in BooleanHypercube::new(ccs.s).into_iter() {
-        for j in 0..vec_L.len() {
+      for x in BooleanHypercube::new(ccs.s) {
+        for (j, coeff) in vec_L.iter().enumerate() {
           let gamma_j = gamma.pow([j as u64]);
-          sum_Lj_on_bhc += vec_L[j].evaluate(&x).unwrap() * gamma_j;
+          sum_Lj_on_bhc += coeff.evaluate(&x).unwrap() * gamma_j;
         }
       }
 

--- a/src/ccs/util/mod.rs
+++ b/src/ccs/util/mod.rs
@@ -43,7 +43,7 @@ pub fn compute_sum_Mz<G: Group>(
 
   let bhc = BooleanHypercube::<G::Scalar>::new(z.get_num_vars());
   for y in bhc.into_iter() {
-    let M_y = fix_variables(&M_mle, &y);
+    let M_y = fix_variables(M_mle, &y);
 
     // reverse y to match spartan/polynomial evaluate
     let y_rev: Vec<G::Scalar> = y.into_iter().rev().collect();
@@ -175,7 +175,7 @@ mod tests {
       let mut last_vars_fixed = A_mle.clone();
       // this is equivalent to Espresso/hyperplonk's 'fix_last_variables' mehthod
       for bit in y.clone().iter().rev() {
-        last_vars_fixed.bound_poly_var_top(&bit)
+        last_vars_fixed.bound_poly_var_top(bit)
       }
 
       assert_eq!(last_vars_fixed.Z, row_i);
@@ -183,7 +183,7 @@ mod tests {
   }
 
   #[test]
-  fn test_compute_sum_Mz_over_boolean_hypercube() -> () {
+  fn test_compute_sum_Mz_over_boolean_hypercube() {
     let z = CCSShape::<Ep>::get_test_z(3);
     let (ccs, _, _) = CCSShape::<Ep>::gen_test_ccs(&z);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 )]
 #![allow(non_snake_case)]
 #![allow(clippy::type_complexity)]
+#![allow(clippy::upper_case_acronyms)]
 #![forbid(unsafe_code)]
 
 // private modules

--- a/src/spartan/polynomial.rs
+++ b/src/spartan/polynomial.rs
@@ -270,11 +270,11 @@ mod tests {
     assert_eq!(y, Fp::one());
 
     let eval_list = eq_poly.evals();
-    for i in 0..(2_usize).pow(3) {
+    for (i, &coeff) in eval_list.iter().enumerate().take((2_usize).pow(3)) {
       if i == 5 {
-        assert_eq!(eval_list[i], Fp::one());
+        assert_eq!(coeff, Fp::one());
       } else {
-        assert_eq!(eval_list[i], Fp::zero());
+        assert_eq!(coeff, Fp::zero());
       }
     }
   }


### PR DESCRIPTION
As seen in previous CI runs:
- 4ae0cf70141a9036c719e356a69fd36ab9295b02
- cde23f39cb143cf2a327cf0fd0e78bb16b01cc07
- ca55e738fdac5367f906889bae3e2b9d7126ad00

The clippy job is causing the CI to fail due to missing fixes on the code.
This gets up to speed the codebase with Clippy recommendations and leaves the Uppercase warning disabled.

Resolves: #35 