### PR TITLE
refactor(virtual_poly): Remove unnecessary default from PhantomData

### DIFF
--- a/src/ccs/util/virtual_poly.rs
+++ b/src/ccs/util/virtual_poly.rs
@@ -117,7 +117,7 @@ impl<F: PrimeField> VirtualPolynomial<F> {
       aux_info: VPAuxInfo {
         max_degree: 0,
         num_variables,
-        phantom: PhantomData::default(),
+        phantom: PhantomData,
       },
       products: Vec::new(),
       flattened_ml_extensions: Vec::new(),
@@ -136,7 +136,7 @@ impl<F: PrimeField> VirtualPolynomial<F> {
         // The max degree is the max degree of any individual variable
         max_degree: 1,
         num_variables: mle.get_num_vars(),
-        phantom: PhantomData::default(),
+        phantom: PhantomData,
       },
       // here `0` points to the first polynomial of `flattened_ml_extensions`
       products: vec![(coefficient, vec![0])],


### PR DESCRIPTION
Fixes additional clippy errors I see when I upgraded my Rust toolchain (had some issues with clippy and Homebrew)

```
error: use of `default` to create a unit struct
   --> src/ccs/util/virtual_poly.rs:120:29
    |
120 |         phantom: PhantomData::default(),
    |                             ^^^^^^^^^^^ help: remove this call to `default`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#default_constructed_unit_structs
note: the lint level is defined here
```