### PR TITLE
NIMFS-centric API refactor for multifolding impl

### DIFF
--- a/src/ccs/cccs.rs
+++ b/src/ccs/cccs.rs
@@ -105,7 +105,6 @@ impl<G: Group> CCCS<G> {
     &self,
     ccs: &CCS<G>,
     ccs_mles: &[MultilinearPolynomial<G::Scalar>],
-    ck: &CommitmentKey<G>,
     beta: &[G::Scalar],
   ) -> Result<VirtualPolynomial<G::Scalar>, NovaError> {
     let q = self.compute_q(ccs, ccs_mles)?;
@@ -205,7 +204,7 @@ mod tests {
     let beta: Vec<G::Scalar> = (0..ccs.s).map(|_| G::Scalar::random(&mut rng)).collect();
     // Compute Q(x) = eq(beta, x) * q(x).
     let Q = cccs
-      .compute_Q(&ccs, &mles, &ck, &beta)
+      .compute_Q(&ccs, &mles, &beta)
       .expect("Computation of Q should not fail");
 
     // Let's consider the multilinear polynomial G(x) = \sum_{y \in {0, 1}^s} eq(x, y) q(y)
@@ -247,7 +246,7 @@ mod tests {
 
     for d in BooleanHypercube::new(ccs.s) {
       let Q_at_d = cccs
-        .compute_Q(&ccs, &mles, &ck, &d)
+        .compute_Q(&ccs, &mles, &d)
         .expect("Computing Q_at_d shouldn't fail");
 
       // Get G(d) by summing over Q_d(x) over the hypercube
@@ -260,7 +259,7 @@ mod tests {
     // Now test that they should disagree outside of the hypercube
     let r: Vec<G::Scalar> = (0..ccs.s).map(|_| G::Scalar::random(&mut rng)).collect();
     let Q_at_r = cccs
-      .compute_Q(&ccs, &mles, &ck, &r)
+      .compute_Q(&ccs, &mles, &r)
       .expect("Computing Q_at_r shouldn't fail");
 
     // Get G(d) by summing over Q_d(x) over the hypercube

--- a/src/ccs/cccs.rs
+++ b/src/ccs/cccs.rs
@@ -167,11 +167,11 @@ mod tests {
   fn test_compute_q_with<G: Group>() {
     let mut rng = OsRng;
 
-    let z = CCS::<Ep>::get_test_z(3);
-    let (ccs, ccs_witness, ccs_instance, mles) = CCS::<Ep>::gen_test_ccs(&z);
+    let z = CCS::<G>::get_test_z(3);
+    let (ccs, ccs_witness, ccs_instance, mles) = CCS::<G>::gen_test_ccs(&z);
 
     // generate ck
-    let ck = CCS::<Ep>::commitment_key(&ccs);
+    let ck = CCS::<G>::commitment_key(&ccs);
     // ensure CCS is satisfied
     ccs.is_sat(&ck, &ccs_instance, &ccs_witness).unwrap();
 
@@ -180,25 +180,23 @@ mod tests {
     let q = cccs.compute_q(&ccs, &mles).unwrap();
 
     // Evaluate inside the hypercube
-    BooleanHypercube::new(ccs_shape.s).for_each(|x| {
+    BooleanHypercube::new(ccs.s).for_each(|x| {
       assert_eq!(G::Scalar::ZERO, q.evaluate(&x).unwrap());
     });
 
     // Evaluate outside the hypercube
-    let beta: Vec<G::Scalar> = (0..ccs_shape.s)
-      .map(|_| G::Scalar::random(&mut rng))
-      .collect();
+    let beta: Vec<G::Scalar> = (0..ccs.s).map(|_| G::Scalar::random(&mut rng)).collect();
     assert_ne!(G::Scalar::ZERO, q.evaluate(&beta).unwrap());
   }
 
   fn test_compute_Q_with<G: Group>() {
     let mut rng = OsRng;
 
-    let z = CCS::<Ep>::get_test_z(3);
-    let (ccs, ccs_witness, ccs_instance, mles) = CCS::<Ep>::gen_test_ccs(&z);
+    let z = CCS::<G>::get_test_z(3);
+    let (ccs, ccs_witness, ccs_instance, mles) = CCS::<G>::gen_test_ccs(&z);
 
     // generate ck
-    let ck = CCS::<Ep>::commitment_key(&ccs);
+    let ck = CCS::<G>::commitment_key(&ccs);
     // ensure CCS is satisfied
     ccs.is_sat(&ck, &ccs_instance, &ccs_witness).unwrap();
 
@@ -231,11 +229,11 @@ mod tests {
   fn test_Q_against_q_with<G: Group>() {
     let mut rng = OsRng;
 
-    let z = CCS::<Ep>::get_test_z(3);
-    let (ccs, ccs_witness, ccs_instance, mles) = CCS::<Ep>::gen_test_ccs(&z);
+    let z = CCS::<G>::get_test_z(3);
+    let (ccs, ccs_witness, ccs_instance, mles) = CCS::<G>::gen_test_ccs(&z);
 
     // generate ck
-    let ck = CCS::<Ep>::commitment_key(&ccs);
+    let ck = CCS::<G>::commitment_key(&ccs);
     // ensure CCS is satisfied
     ccs.is_sat(&ck, &ccs_instance, &ccs_witness).unwrap();
 

--- a/src/ccs/cccs.rs
+++ b/src/ccs/cccs.rs
@@ -45,13 +45,17 @@ pub struct CCCS<G: Group> {
 impl<G: Group> CCCS<G> {
   /// Generates a new CCCS given a reference to it's original CCS repr & the multilinear extension of it's matrixes.
   /// Then, given the input vector `z`.
-  pub fn new(
+  pub(crate) fn new(
     ccs: &CCS<G>,
     ccs_matrix_mle: &Vec<MultilinearPolynomial<G::Scalar>>,
     z: Vec<G::Scalar>,
     ck: &CommitmentKey<G>,
   ) -> Self {
-    let x_comm = CE::<G>::commit(ck, &z[1..ccs.l]);
+    let x_comm = if ccs.l != 0 {
+      CE::<G>::commit(ck, &z[1..ccs.l + 1])
+    } else {
+      Commitment::<G>::default()
+    };
     let w_comm = CE::<G>::commit(ck, &z[(1 + ccs.l)..]);
 
     Self {

--- a/src/ccs/cccs.rs
+++ b/src/ccs/cccs.rs
@@ -44,7 +44,7 @@ impl<G: Group> CCCS<G> {
   /// Generates a new CCCS given a reference to it's original CCS repr and it's public and private inputs.
   pub(crate) fn new(
     ccs: &CCS<G>,
-    ccs_matrix_mle: &Vec<MultilinearPolynomial<G::Scalar>>,
+    ccs_matrix_mle: &[MultilinearPolynomial<G::Scalar>],
     z: Vec<G::Scalar>,
     ck: &CommitmentKey<G>,
   ) -> Self {

--- a/src/ccs/cccs.rs
+++ b/src/ccs/cccs.rs
@@ -43,8 +43,8 @@ pub struct CCCS<G: Group> {
 }
 
 impl<G: Group> CCCS<G> {
-  // Generates a new CCCS given a reference to it's original CCS repr & the multilinear extension of it's matrixes.
-  // Then, given the input vector `z`.
+  /// Generates a new CCCS given a reference to it's original CCS repr & the multilinear extension of it's matrixes.
+  /// Then, given the input vector `z`.
   pub fn new(
     ccs: &CCS<G>,
     ccs_matrix_mle: &Vec<MultilinearPolynomial<G::Scalar>>,
@@ -61,9 +61,9 @@ impl<G: Group> CCCS<G> {
     }
   }
 
-  // Computes q(x) = \sum^q c_i * \prod_{j \in S_i} ( \sum_{y \in {0,1}^s'} M_j(x, y) * z(y) )
-  // polynomial over x
-  pub fn compute_q(
+  /// Computes q(x) = \sum^q c_i * \prod_{j \in S_i} ( \sum_{y \in {0,1}^s'} M_j(x, y) * z(y) )
+  /// polynomial over x
+  pub(crate) fn compute_q(
     &self,
     ccs: &CCS<G>,
     ccs_mles: &[MultilinearPolynomial<G::Scalar>],

--- a/src/ccs/cccs.rs
+++ b/src/ccs/cccs.rs
@@ -31,37 +31,28 @@ use super::util::virtual_poly::VirtualPolynomial;
 use super::CCS;
 
 /// A type that holds the shape of a Committed CCS (CCCS) instance
-#[derive(Clone, Debug, PartialEq, Eq /*Serialize, Deserialize*/)]
-//#[serde(bound(deserialize = "'de: 'a"))]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(bound = "")]
 pub struct CCCS<G: Group> {
   // The `z` vector used as input for this instance.
   pub(crate) z: Vec<G::Scalar>,
   // Commitment to the witness of `z`.
   pub(crate) w_comm: Commitment<G>,
-  // Commitment to the public inputs of `z`.
-  pub(crate) x_comm: Commitment<G>,
 }
 
 impl<G: Group> CCCS<G> {
-  /// Generates a new CCCS given a reference to it's original CCS repr & the multilinear extension of it's matrixes.
-  /// Then, given the input vector `z`.
+  /// Generates a new CCCS given a reference to it's original CCS repr and it's public and private inputs.
   pub(crate) fn new(
     ccs: &CCS<G>,
     ccs_matrix_mle: &Vec<MultilinearPolynomial<G::Scalar>>,
     z: Vec<G::Scalar>,
     ck: &CommitmentKey<G>,
   ) -> Self {
-    let x_comm = if ccs.l != 0 {
-      CE::<G>::commit(ck, &z[1..ccs.l + 1])
-    } else {
-      Commitment::<G>::default()
-    };
     let w_comm = CE::<G>::commit(ck, &z[(1 + ccs.l)..]);
 
     Self {
       z: z.to_vec(),
       w_comm,
-      x_comm,
     }
   }
 
@@ -142,14 +133,6 @@ impl<G: Group> CCCS<G> {
 
     Ok(())
   }
-
-  // XXX: Pending to add a commit fn:
-
-  // let w: Vec<G::Scalar> = z[(1 + self.l)..].to_vec();
-  // XXX: API doesn't offer a way to handle this apparently?
-  // Need to investigate
-  // let _r_w = G::Scalar::random(rng);
-  // let C = <<G as Group>::CE as CommitmentEngineTrait<G>>::commit(ck, &w);
 }
 
 #[cfg(test)]

--- a/src/ccs/lcccs.rs
+++ b/src/ccs/lcccs.rs
@@ -52,19 +52,19 @@ impl<G: Group> LCCCS<G> {
     z: Vec<G::Scalar>,
     mut rng: &mut R,
   ) -> Self {
-    let r_w = G::Scalar::random(&mut rng);
+    // XXX: API doesn't offer a way to handle this??
+    let _r_w = G::Scalar::random(&mut rng);
     let w_comm = <<G as Group>::CE as CommitmentEngineTrait<G>>::commit(ck, &z[(1 + ccs.l)..]);
 
-    // XXX: API doesn't offer a way to handle this??
-    let _r_x: Vec<G::Scalar> = (0..ccs.s).map(|_| G::Scalar::random(&mut rng)).collect();
-
-    let v = ccs.compute_v_j(&z, &_r_x, ccs_m_mle);
+    // Evaluation points for `v`
+    let r_x: Vec<G::Scalar> = (0..ccs.s).map(|_| G::Scalar::random(&mut rng)).collect();
+    let v = ccs.compute_v_j(&z, &r_x, ccs_m_mle);
 
     Self {
       w_comm,
       u: G::Scalar::ONE,
       v,
-      r_x: _r_x,
+      r_x,
       z,
     }
   }

--- a/src/ccs/lcccs.rs
+++ b/src/ccs/lcccs.rs
@@ -44,6 +44,7 @@ pub struct LCCCS<G: Group> {
 impl<G: Group> LCCCS<G> {
   /// Generates a new LCCCS instance from a given randomness, CommitmentKey & witness input vector.
   /// This should only be used to probably test or setup the initial NIMFS instance.
+  #[cfg(test)]
   pub(crate) fn new<R: RngCore>(
     ccs: &CCS<G>,
     ccs_m_mle: &[MultilinearPolynomial<G::Scalar>],
@@ -69,12 +70,15 @@ impl<G: Group> LCCCS<G> {
     ccs_m_mle: &[MultilinearPolynomial<G::Scalar>],
     ck: &CommitmentKey<G>,
   ) -> Result<(), NovaError> {
+    dbg!(self.z.clone());
     let w = &self.z[(1 + ccs.l)..];
     // check that C is the commitment of w. Notice that this is not verifying a Pedersen
     // opening, but checking that the Commmitment comes from committing to the witness.
     let comm_eq = self.w_comm == CE::<G>::commit(ck, w);
 
     let computed_v = compute_all_sum_Mz_evals::<G>(ccs_m_mle, &self.z, &self.r_x, ccs.s_prime);
+    dbg!(self.v.clone());
+    dbg!(computed_v.clone());
     let vs_eq = computed_v == self.v;
 
     if vs_eq && comm_eq {
@@ -84,8 +88,7 @@ impl<G: Group> LCCCS<G> {
     }
   }
 
-  /// Compute all L_j(x) polynomials
-  // Can we recieve the MLE of z directy?
+  /// Compute all L_j(x) polynomials.
   pub fn compute_Ls(
     &self,
     ccs: &CCS<G>,

--- a/src/ccs/lcccs.rs
+++ b/src/ccs/lcccs.rs
@@ -1,5 +1,5 @@
 use super::util::{compute_sum_Mz, VirtualPolynomial};
-use super::{CCSShape, CCSWitness};
+use super::{CCSWitness, CCS};
 use crate::ccs::util::compute_all_sum_Mz_evals;
 use crate::hypercube::BooleanHypercube;
 use crate::spartan::math::Math;
@@ -41,7 +41,7 @@ pub struct LCCCS<G: Group> {
   pub r_x: Vec<G::Scalar>,
   // This should not need to be here. Should be a reference only.
   pub(crate) matrix_mles: Vec<MultilinearPolynomial<G::Scalar>>,
-  pub(crate) ccs: CCSShape<G>,
+  pub(crate) ccs: CCS<G>,
 }
 
 impl<G: Group> LCCCS<G> {
@@ -104,8 +104,8 @@ mod tests {
 
   fn satisfied_ccs_is_satisfied_lcccs_with<G: Group>() {
     // Gen test vectors & artifacts
-    let z = CCSShape::<G>::get_test_z(3);
-    let (ccs, witness, instance) = CCSShape::<G>::gen_test_ccs(&z);
+    let z = CCS::<Ep>::get_test_z(3);
+    let (ccs, witness, instance) = CCS::<Ep>::gen_test_ccs(&z);
     let ck = ccs.commitment_key();
     assert!(ccs.is_sat(&ck, &instance, &witness).is_ok());
 
@@ -127,8 +127,8 @@ mod tests {
     let mut rng = OsRng;
 
     // Gen test vectors & artifacts
-    let z = CCSShape::<G>::get_test_z(3);
-    let (ccs, _, _) = CCSShape::<G>::gen_test_ccs(&z);
+    let z = CCS::<Ep>::get_test_z(3);
+    let (ccs, _, _) = CCS::<Ep>::gen_test_ccs(&z);
     let ck = ccs.commitment_key();
 
     // Get LCCCS
@@ -149,8 +149,8 @@ mod tests {
     let mut rng = OsRng;
 
     // Gen test vectors & artifacts
-    let z = CCSShape::<G>::get_test_z(3);
-    let (ccs, _, _) = CCSShape::<G>::gen_test_ccs(&z);
+    let z = CCS::<Ep>::get_test_z(3);
+    let (ccs, witness, instance) = CCS::<Ep>::gen_test_ccs(&z);
     let ck = ccs.commitment_key();
 
     // Mutate z so that the relation does not hold

--- a/src/ccs/lcccs.rs
+++ b/src/ccs/lcccs.rs
@@ -84,6 +84,9 @@ impl<G: Group> LCCCS<G> {
     let computed_v = compute_all_sum_Mz_evals::<G>(ccs_m_mle, &self.z, &self.r_x, ccs.s_prime);
     let vs_eq = computed_v == self.v;
 
+    dbg!(vs_eq);
+    dbg!(comm_eq);
+
     if vs_eq && comm_eq {
       Ok(())
     } else {
@@ -131,7 +134,7 @@ mod tests {
     assert!(ccs.is_sat(&ck, &instance, &witness).is_ok());
 
     // LCCCS with the correct z should pass
-    let lcccs = LCCCS::new(&ccs, &mles, &ck, z, &mut OsRng);
+    let mut lcccs = LCCCS::new(&ccs, &mles, &ck, z, &mut OsRng);
     assert!(lcccs.is_sat(&ccs, &mles, &ck).is_ok());
 
     // Wrong z so that the relation does not hold
@@ -139,8 +142,7 @@ mod tests {
     bad_z[3] = G::Scalar::ZERO;
 
     // LCCCS with the wrong z should not pass `is_sat`.
-    // LCCCS with the correct z should pass
-    let lcccs = LCCCS::new(&ccs, &mles, &ck, bad_z, &mut OsRng);
+    lcccs.z = bad_z;
     assert!(lcccs.is_sat(&ccs, &mles, &ck).is_err());
   }
 

--- a/src/ccs/lcccs.rs
+++ b/src/ccs/lcccs.rs
@@ -1,5 +1,5 @@
 use super::util::{compute_sum_Mz, VirtualPolynomial};
-use super::{CCSWitness, CCS};
+use super::{CCCSInstance, CCSWitness, CCS};
 use crate::ccs::util::compute_all_sum_Mz_evals;
 use crate::hypercube::BooleanHypercube;
 use crate::spartan::math::Math;
@@ -33,40 +33,38 @@ use std::sync::Arc;
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct LCCCS<G: Group> {
-  pub(crate) C: Commitment<G>,
+  pub(crate) w_comm: Commitment<G>,
   pub(crate) x: Vec<G::Scalar>,
   pub(crate) u: G::Scalar,
   pub(crate) v: Vec<G::Scalar>,
   // Random evaluation point for the v_i
   pub r_x: Vec<G::Scalar>,
-  // This should not need to be here. Should be a reference only.
-  pub(crate) matrix_mles: Vec<MultilinearPolynomial<G::Scalar>>,
-  pub(crate) ccs: CCS<G>,
+  pub(crate) z: Vec<G::Scalar>,
 }
 
 impl<G: Group> LCCCS<G> {
   // XXX: Double check that this is indeed correct.
   /// Samples public parameters for the specified number of constraints and variables in an CCS
-  pub fn commitment_key(&self) -> CommitmentKey<G> {
-    let total_nz = self.ccs.M.iter().fold(0, |acc, m| acc + m.coeffs().len());
+  // pub fn commitment_key(&self) -> CommitmentKey<G> {
+  //   let total_nz = self.ccs.M.iter().fold(0, |acc, m| acc + m.coeffs().len());
 
-    G::CE::setup(b"ck", max(max(self.ccs.m, self.ccs.t), total_nz))
-  }
+  //   G::CE::setup(b"ck", max(max(self.ccs.m, self.ccs.t), total_nz))
+  // }
 
   /// Checks if the CCS instance is satisfiable given a witness and its shape
-  pub fn is_sat(&self, ck: &CommitmentKey<G>, W: &CCSWitness<G>) -> Result<(), NovaError> {
+  pub fn is_sat(
+    &self,
+    ccs: &CCS<G>,
+    ccs_m_mle: &[MultilinearPolynomial<G::Scalar>],
+    ck: &CommitmentKey<G>,
+  ) -> Result<(), NovaError> {
+    let w = &self.z[(1 + ccs.l)..];
     // check that C is the commitment of w. Notice that this is not verifying a Pedersen
     // opening, but checking that the Commmitment comes from committing to the witness.
-    let comm_eq = self.C == CE::<G>::commit(ck, &W.w);
+    let comm_eq = self.w_comm == CE::<G>::commit(ck, w);
 
-    // check CCS relation
-    let z: Vec<G::Scalar> = [vec![self.u], self.x.clone(), W.w.to_vec()].concat();
-    let computed_v =
-      compute_all_sum_Mz_evals::<G>(&self.matrix_mles, &z, &self.r_x, self.ccs.s_prime);
+    let computed_v = compute_all_sum_Mz_evals::<G>(ccs_m_mle, w, &self.r_x, ccs.s_prime);
     let vs_eq = computed_v == self.v;
-
-    dbg!(vs_eq);
-    dbg!(comm_eq);
 
     if vs_eq && comm_eq {
       Ok(())
@@ -77,13 +75,19 @@ impl<G: Group> LCCCS<G> {
 
   /// Compute all L_j(x) polynomials
   // Can we recieve the MLE of z directy?
-  pub fn compute_Ls(&self, z: &Vec<G::Scalar>) -> Vec<VirtualPolynomial<G::Scalar>> {
-    let z_mle = dense_vec_to_mle(self.ccs.s_prime, z);
+  pub fn compute_Ls(
+    &self,
+    ccs: &CCS<G>,
+    ccs_m_mle: &[MultilinearPolynomial<G::Scalar>],
+    ck: &CommitmentKey<G>,
+    z: &[G::Scalar],
+  ) -> Vec<VirtualPolynomial<G::Scalar>> {
+    let z_mle = dense_vec_to_mle(ccs.s_prime, z);
 
-    let mut vec_L_j_x = Vec::with_capacity(self.ccs.t);
-    for M_j in self.matrix_mles.iter() {
+    let mut vec_L_j_x = Vec::with_capacity(ccs.t);
+    for M_j in ccs_m_mle.iter() {
       // Sanity check
-      assert_eq!(z_mle.get_num_vars(), self.ccs.s_prime);
+      assert_eq!(z_mle.get_num_vars(), ccs.s_prime);
 
       let sum_Mz = compute_sum_Mz::<G>(M_j, &z_mle);
       let sum_Mz_virtual = VirtualPolynomial::new_from_mle(&Arc::new(sum_Mz), G::Scalar::ONE);
@@ -105,7 +109,7 @@ mod tests {
   fn satisfied_ccs_is_satisfied_lcccs_with<G: Group>() {
     // Gen test vectors & artifacts
     let z = CCS::<Ep>::get_test_z(3);
-    let (ccs, witness, instance) = CCS::<Ep>::gen_test_ccs(&z);
+    let (ccs, witness, instance, mles) = CCS::<Ep>::gen_test_ccs(&z);
     let ck = ccs.commitment_key();
     assert!(ccs.is_sat(&ck, &instance, &witness).is_ok());
 

--- a/src/ccs/lcccs.rs
+++ b/src/ccs/lcccs.rs
@@ -120,13 +120,13 @@ mod tests {
 
   fn satisfied_ccs_is_satisfied_lcccs_with<G: Group>() {
     // Gen test vectors & artifacts
-    let z = CCS::<Ep>::get_test_z(3);
-    let (ccs, witness, instance, mles) = CCS::<Ep>::gen_test_ccs(&z);
+    let z = CCS::<G>::get_test_z(3);
+    let (ccs, witness, instance, mles) = CCS::<G>::gen_test_ccs(&z);
     let ck = ccs.commitment_key();
     assert!(ccs.is_sat(&ck, &instance, &witness).is_ok());
 
     // LCCCS with the correct z should pass
-    let mut lcccs = LCCCS::new(&ccs, &mles, &ck, z, &mut OsRng);
+    let mut lcccs = LCCCS::new(&ccs, &mles, &ck, z.clone(), &mut OsRng);
     assert!(lcccs.is_sat(&ccs, &mles, &ck).is_ok());
 
     // Wrong z so that the relation does not hold
@@ -142,8 +142,8 @@ mod tests {
     let mut rng = OsRng;
 
     // Gen test vectors & artifacts
-    let z = CCS::<Ep>::get_test_z(3);
-    let (ccs, _, _, mles) = CCS::<Ep>::gen_test_ccs(&z);
+    let z = CCS::<G>::get_test_z(3);
+    let (ccs, _, _, mles) = CCS::<G>::gen_test_ccs(&z);
     let ck = ccs.commitment_key();
 
     // Get LCCCS
@@ -164,8 +164,8 @@ mod tests {
     let mut rng = OsRng;
 
     // Gen test vectors & artifacts
-    let z = CCS::<Ep>::get_test_z(3);
-    let (ccs, witness, instance, mles) = CCS::<Ep>::gen_test_ccs(&z);
+    let z = CCS::<G>::get_test_z(3);
+    let (ccs, witness, instance, mles) = CCS::<G>::gen_test_ccs(&z);
     let ck = ccs.commitment_key();
 
     // Mutate z so that the relation does not hold

--- a/src/ccs/lcccs.rs
+++ b/src/ccs/lcccs.rs
@@ -31,7 +31,7 @@ use std::ops::{Add, Mul};
 use std::sync::Arc;
 
 /// A type that holds a LCCCS instance
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct LCCCS<G: Group> {
   pub(crate) w_comm: Commitment<G>,
@@ -44,7 +44,6 @@ pub struct LCCCS<G: Group> {
 impl<G: Group> LCCCS<G> {
   /// Generates a new LCCCS instance from a given randomness, CommitmentKey & witness input vector.
   /// This should only be used to probably test or setup the initial NIMFS instance.
-  #[cfg(test)]
   pub(crate) fn new<R: RngCore>(
     ccs: &CCS<G>,
     ccs_m_mle: &[MultilinearPolynomial<G::Scalar>],

--- a/src/ccs/lcccs.rs
+++ b/src/ccs/lcccs.rs
@@ -77,9 +77,6 @@ impl<G: Group> LCCCS<G> {
     let computed_v = compute_all_sum_Mz_evals::<G>(ccs_m_mle, &self.z, &self.r_x, ccs.s_prime);
     let vs_eq = computed_v == self.v;
 
-    dbg!(vs_eq);
-    dbg!(comm_eq);
-
     if vs_eq && comm_eq {
       Ok(())
     } else {

--- a/src/ccs/lcccs.rs
+++ b/src/ccs/lcccs.rs
@@ -1,5 +1,5 @@
 use super::util::{compute_sum_Mz, VirtualPolynomial};
-use super::{CCCSInstance, CCSWitness, CCS};
+use super::{CCSWitness, CCCS, CCS};
 use crate::ccs::util::compute_all_sum_Mz_evals;
 use crate::hypercube::BooleanHypercube;
 use crate::spartan::math::Math;

--- a/src/ccs/lcccs.rs
+++ b/src/ccs/lcccs.rs
@@ -92,7 +92,6 @@ impl<G: Group> LCCCS<G> {
     &self,
     ccs: &CCS<G>,
     ccs_m_mle: &[MultilinearPolynomial<G::Scalar>],
-    ck: &CommitmentKey<G>,
   ) -> Vec<VirtualPolynomial<G::Scalar>> {
     let z_mle = dense_vec_to_mle(ccs.s_prime, self.z.as_slice());
 
@@ -149,7 +148,7 @@ mod tests {
     // Get LCCCS
     let lcccs = LCCCS::new(&ccs, &mles, &ck, z, &mut OsRng);
 
-    let vec_L_j_x = lcccs.compute_Ls(&ccs, &mles, &ck);
+    let vec_L_j_x = lcccs.compute_Ls(&ccs, &mles);
     assert_eq!(vec_L_j_x.len(), lcccs.v.len());
 
     for (v_i, L_j_x) in lcccs.v.into_iter().zip(vec_L_j_x) {
@@ -179,7 +178,7 @@ mod tests {
 
     // Compute L_j(x) with the bad z
     lcccs.z = bad_z;
-    let vec_L_j_x = lcccs.compute_Ls(&ccs, &mles, &ck);
+    let vec_L_j_x = lcccs.compute_Ls(&ccs, &mles);
     assert_eq!(vec_L_j_x.len(), lcccs.v.len());
     // Assert LCCCS is not satisfied with the bad Z
     assert!(lcccs.is_sat(&ccs, &mles, &ck).is_err());

--- a/src/ccs/lcccs.rs
+++ b/src/ccs/lcccs.rs
@@ -98,9 +98,8 @@ impl<G: Group> LCCCS<G> {
     ccs: &CCS<G>,
     ccs_m_mle: &[MultilinearPolynomial<G::Scalar>],
     ck: &CommitmentKey<G>,
-    z: &[G::Scalar],
   ) -> Vec<VirtualPolynomial<G::Scalar>> {
-    let z_mle = dense_vec_to_mle(ccs.s_prime, z);
+    let z_mle = dense_vec_to_mle(ccs.s_prime, self.z.as_slice());
 
     let mut vec_L_j_x = Vec::with_capacity(ccs.t);
     for M_j in ccs_m_mle.iter() {
@@ -156,7 +155,7 @@ mod tests {
     // Get LCCCS
     let lcccs = LCCCS::new(&ccs, &mles, &ck, z, &mut OsRng);
 
-    let vec_L_j_x = lcccs.compute_Ls(&ccs, &mles, &ck, &z);
+    let vec_L_j_x = lcccs.compute_Ls(&ccs, &mles, &ck);
     assert_eq!(vec_L_j_x.len(), lcccs.v.len());
 
     for (v_i, L_j_x) in lcccs.v.into_iter().zip(vec_L_j_x) {
@@ -186,7 +185,7 @@ mod tests {
 
     // Compute L_j(x) with the bad z
     let lcccs = LCCCS::new(&ccs, &mles, &ck, bad_z, &mut OsRng);
-    let vec_L_j_x = lcccs.compute_Ls(&ccs, &mles, &ck, &bad_z);
+    let vec_L_j_x = lcccs.compute_Ls(&ccs, &mles, &ck);
     assert_eq!(vec_L_j_x.len(), lcccs.v.len());
     // Assert LCCCS is not satisfied with the bad Z
     assert!(lcccs.is_sat(&ccs, &mles, &ck).is_err());

--- a/src/ccs/lcccs.rs
+++ b/src/ccs/lcccs.rs
@@ -35,7 +35,6 @@ use std::sync::Arc;
 #[serde(bound = "")]
 pub struct LCCCS<G: Group> {
   pub(crate) w_comm: Commitment<G>,
-  pub(crate) u: G::Scalar,
   pub(crate) v: Vec<G::Scalar>,
   // Random evaluation point for the v_i
   pub r_x: Vec<G::Scalar>,
@@ -60,13 +59,7 @@ impl<G: Group> LCCCS<G> {
     let r_x: Vec<G::Scalar> = (0..ccs.s).map(|_| G::Scalar::random(&mut rng)).collect();
     let v = ccs.compute_v_j(&z, &r_x, ccs_m_mle);
 
-    Self {
-      w_comm,
-      u: G::Scalar::ONE,
-      v,
-      r_x,
-      z,
-    }
+    Self { w_comm, v, r_x, z }
   }
 
   /// Checks if the CCS instance is satisfiable given a witness and its shape

--- a/src/ccs/lcccs.rs
+++ b/src/ccs/lcccs.rs
@@ -81,7 +81,7 @@ impl<G: Group> LCCCS<G> {
     // opening, but checking that the Commmitment comes from committing to the witness.
     let comm_eq = self.w_comm == CE::<G>::commit(ck, w);
 
-    let computed_v = compute_all_sum_Mz_evals::<G>(ccs_m_mle, w, &self.r_x, ccs.s_prime);
+    let computed_v = compute_all_sum_Mz_evals::<G>(ccs_m_mle, &self.z, &self.r_x, ccs.s_prime);
     let vs_eq = computed_v == self.v;
 
     if vs_eq && comm_eq {
@@ -179,12 +179,12 @@ mod tests {
     bad_z[3] = G::Scalar::ZERO;
 
     // Compute v_j with the right z
-    let lcccs = LCCCS::new(&ccs, &mles, &ck, z, &mut OsRng);
+    let mut lcccs = LCCCS::new(&ccs, &mles, &ck, z, &mut OsRng);
     // Assert LCCCS is satisfied with the original Z
     assert!(lcccs.is_sat(&ccs, &mles, &ck).is_ok());
 
     // Compute L_j(x) with the bad z
-    let lcccs = LCCCS::new(&ccs, &mles, &ck, bad_z, &mut OsRng);
+    lcccs.z = bad_z;
     let vec_L_j_x = lcccs.compute_Ls(&ccs, &mles, &ck);
     assert_eq!(vec_L_j_x.len(), lcccs.v.len());
     // Assert LCCCS is not satisfied with the bad Z

--- a/src/ccs/lcccs.rs
+++ b/src/ccs/lcccs.rs
@@ -37,7 +37,7 @@ pub struct LCCCS<G: Group> {
   pub(crate) w_comm: Commitment<G>,
   pub(crate) v: Vec<G::Scalar>,
   // Random evaluation point for the v_i
-  pub r_x: Vec<G::Scalar>,
+  pub(crate) r_x: Vec<G::Scalar>,
   pub(crate) z: Vec<G::Scalar>,
 }
 

--- a/src/ccs/mod.rs
+++ b/src/ccs/mod.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
 use sha3::{Digest, Sha3_256};
 use std::ops::{Add, Mul};
 
-use self::cccs::CCCSInstance;
+use self::cccs::CCCS;
 use self::lcccs::LCCCS;
 use self::util::compute_all_sum_Mz_evals;
 
@@ -187,6 +187,7 @@ impl<G: Group> CCS<G> {
     }
   }
 
+  /// Generate a CCS instance from an [`R1CSShape`] instance.
   pub fn from_r1cs(r1cs: R1CSShape<G>) -> Self {
     // These contants are used for R1CS-to-CCS, see the paper for more details
     const T: usize = 3;

--- a/src/ccs/mod.rs
+++ b/src/ccs/mod.rs
@@ -126,7 +126,7 @@ impl<G: Group> CCS<G> {
     r: &[G::Scalar],
     ccs_matrix_mles: &[MultilinearPolynomial<G::Scalar>],
   ) -> Vec<G::Scalar> {
-    compute_all_sum_Mz_evals::<G>(ccs_matrix_mles, &z.to_vec(), r, self.s_prime)
+    compute_all_sum_Mz_evals::<G>(ccs_matrix_mles, z, r, self.s_prime)
   }
 
   // XXX: Update commitment_key variables here? This is currently based on R1CS with M length

--- a/src/ccs/mod.rs
+++ b/src/ccs/mod.rs
@@ -32,9 +32,10 @@ use serde::{Deserialize, Serialize};
 use sha3::{Digest, Sha3_256};
 use std::ops::{Add, Mul};
 
-use self::cccs::CCCS;
-use self::lcccs::LCCCS;
-use self::util::compute_all_sum_Mz_evals;
+pub use cccs::CCCS;
+pub use lcccs::LCCCS;
+pub use multifolding::NIMFS;
+use util::compute_all_sum_Mz_evals;
 
 mod cccs;
 mod lcccs;
@@ -115,6 +116,11 @@ impl<G: Group> CCS<G> {
       s,
       s_prime,
     }
+  }
+
+  /// Returns the multilinear extension of the CCS matrixes.
+  pub fn matrix_mles(&self) -> Vec<MultilinearPolynomial<G::Scalar>> {
+    self.M.iter().map(|matrix| matrix.to_mle()).collect()
   }
 
   /// Compute v_j values of the linearized committed CCS form

--- a/src/ccs/mod.rs
+++ b/src/ccs/mod.rs
@@ -118,11 +118,6 @@ impl<G: Group> CCS<G> {
     }
   }
 
-  /// Returns the multilinear extension of the CCS matrixes.
-  pub fn matrix_mles(&self) -> Vec<MultilinearPolynomial<G::Scalar>> {
-    self.M.iter().map(|matrix| matrix.to_mle()).collect()
-  }
-
   /// Compute v_j values of the linearized committed CCS form
   /// Given `r`, compute:  \sum_{y \in {0,1}^s'} M_j(r, y) * z(y)
   fn compute_v_j(

--- a/src/ccs/multifolding.rs
+++ b/src/ccs/multifolding.rs
@@ -32,19 +32,19 @@ use sha3::{Digest, Sha3_256};
 use std::ops::{Add, Mul};
 use std::sync::Arc;
 
-/// The Multifolding structure is the center of operations of the folding scheme.
+/// The NIMFS structure is the center of operations of the folding scheme.
 /// Once generated, it allows us to fold any upcomming CCCS instances within it without needing to do much.
 // XXX: Pending to add doc examples.
 #[derive(Debug)]
-pub struct Multifolding<G: Group> {
+pub struct NIMFS<G: Group> {
   ccs: CCS<G>,
   ccs_mle: Vec<MultilinearPolynomial<G::Scalar>>,
   ck: CommitmentKey<G>,
   lcccs: LCCCS<G>,
 }
 
-impl<G: Group> Multifolding<G> {
-  /// Generates a new Multifolding instance based on the given CCS.
+impl<G: Group> NIMFS<G> {
+  /// Generates a new NIMFS instance based on the given CCS.
   pub fn new(
     ccs: CCS<G>,
     ccs_mle: Vec<MultilinearPolynomial<G::Scalar>>,
@@ -106,7 +106,7 @@ impl<G: Group> Multifolding<G> {
     )
   }
 
-  /// Compute the right-hand-side of step 5 of the multifolding scheme
+  /// Compute the right-hand-side of step 5 of the NIMFS scheme
   pub fn compute_c_from_sigmas_and_thetas(
     &self,
     sigmas: &[G::Scalar],
@@ -167,7 +167,7 @@ impl<G: Group> Multifolding<G> {
     g
   }
 
-  /// This folds an upcomming CCCS instance into the LCCCS instance contained within the Multifolding object.
+  /// This folds an upcomming CCCS instance into the LCCCS instance contained within the NIMFS object.
   pub fn fold<R: RngCore>(&mut self, mut rng: &mut R, cccs2: CCCS<G>, rho: G::Scalar) {
     // Compute r_x_prime from a given randomnes.
     let r_x_prime = vec![G::Scalar::random(&mut rng); self.ccs.s];
@@ -192,7 +192,7 @@ impl<G: Group> Multifolding<G> {
     self.fold_z(cccs2, rho);
   }
 
-  /// Folds the current `z` vector of the upcomming CCCS instance together with the LCCCS instance that is contained inside of the Multifolding object.
+  /// Folds the current `z` vector of the upcomming CCCS instance together with the LCCCS instance that is contained inside of the NIMFS object.
   fn fold_z(&mut self, cccs: CCCS<G>, rho: G::Scalar) {
     // Update u first.
     self.lcccs.z[0] += rho;
@@ -224,8 +224,8 @@ mod tests {
   use crate::ccs::{test, util::virtual_poly::build_eq_x_r};
   use pasta_curves::{Ep, Fq};
   use rand_core::OsRng;
-  // NIMFS: Non Interactive Multifolding Scheme
-  type NIMFS<G> = Multifolding<G>;
+  // NIMFS: Non Interactive NIMFS Scheme
+  type NIMFS = NIMFS<Ep>;
 
   fn test_compute_g_with<G: Group>() {
     let z1 = CCS::<G>::get_test_z(3);
@@ -303,7 +303,7 @@ mod tests {
     let lcccs = LCCCS::new(&ccs, &mles, &ck, z1, &mut OsRng);
     let cccs = CCCS::new(&ccs, &mles, z2, &ck);
 
-    // Generate a new multifolding instance
+    // Generate a new NIMFS instance
     let nimfs = NIMFS::new(ccs.clone(), mles.clone(), lcccs, ck.clone());
 
     // XXX: This needs to be properly thought?
@@ -367,8 +367,8 @@ mod tests {
     let cccs = CCCS::new(&ccs, &mles, z2, &ck);
     assert!(cccs.is_sat(&ccs, &mles, &ck).is_ok());
 
-    // Generate a new multifolding instance
-    let mut nimfs = Multifolding::init(&mut rng, ccs, mles, z1);
+    // Generate a new NIMFS instance
+    let mut nimfs = NIMFS::init(&mut rng, ccs, mles, z1);
     assert!(nimfs.is_sat().is_ok());
 
     let rho = Fq::random(&mut rng);

--- a/src/ccs/multifolding.rs
+++ b/src/ccs/multifolding.rs
@@ -59,6 +59,9 @@ impl<G: Group> NIMFS<G> {
     }
   }
 
+  /// Initializes a NIMFS instance given the CCS of it and a first witness vector that satifies it.
+  // XXX: This should probably return an error as we should check whether is satisfied or not.
+  // XXX: This should not ask for the MLEs and should compute them inside.
   pub fn init<R: RngCore>(
     mut rng: &mut R,
     ccs: CCS<G>,
@@ -83,6 +86,7 @@ impl<G: Group> NIMFS<G> {
     }
   }
 
+  /// This function checks whether the current IVC after the last fold performed is satisfied and returns an error if it isn't.
   pub fn is_sat(&self) -> Result<(), NovaError> {
     self.lcccs.is_sat(&self.ccs, &self.ccs_mle, &self.ck)
   }

--- a/src/ccs/multifolding.rs
+++ b/src/ccs/multifolding.rs
@@ -150,13 +150,13 @@ impl<G: Group> NIMFS<G> {
   /// Compute g(x) polynomial for the given inputs.
   pub fn compute_g(
     &self,
-    cccs_instance: &CCCS<G>,
+    cccs: &CCCS<G>,
     gamma: G::Scalar,
     beta: &[G::Scalar],
   ) -> VirtualPolynomial<G::Scalar> {
     let mut vec_L = self.lcccs.compute_Ls(&self.ccs, &self.ccs_mle);
 
-    let mut Q = cccs_instance
+    let mut Q = cccs
       .compute_Q(&self.ccs, &self.ccs_mle, beta)
       .expect("Q comp should not fail");
 
@@ -251,7 +251,7 @@ mod tests {
     let beta: Vec<G::Scalar> = (0..ccs.s).map(|_| G::Scalar::random(&mut rng)).collect();
 
     let lcccs = LCCCS::new(&ccs, &mles, &ck, z1, &mut OsRng);
-    let cccs_instance = CCCS::new(&ccs, &mles, z2, &ck);
+    let cccs = CCCS::new(&ccs, &mles, z2, &ck);
 
     let mut sum_v_j_gamma = G::Scalar::ZERO;
     for j in 0..lcccs.v.len() {
@@ -262,7 +262,7 @@ mod tests {
     let nimfs = NIMFS::<G>::new(ccs.clone(), mles.clone(), lcccs.clone(), ck.clone());
 
     // Compute g(x) with that r_x
-    let g = nimfs.compute_g(&cccs_instance, gamma, &beta);
+    let g = nimfs.compute_g(&cccs, gamma, &beta);
 
     // evaluate g(x) over x \in {0,1}^s
     let mut g_on_bhc = G::Scalar::ZERO;

--- a/src/ccs/multifolding.rs
+++ b/src/ccs/multifolding.rs
@@ -97,7 +97,7 @@ impl<G: Group> NIMFS<G> {
     &self,
     // Note `z2` represents the input of the incoming CCCS instance.
     // As the current IVC accumulated input is holded inside of the NIMFS(`self`).
-    z2: &[G::Scalar],
+    z: &[G::Scalar],
     r_x_prime: &[G::Scalar],
   ) -> (Vec<G::Scalar>, Vec<G::Scalar>) {
     (

--- a/src/ccs/multifolding.rs
+++ b/src/ccs/multifolding.rs
@@ -224,8 +224,6 @@ mod tests {
   use crate::ccs::{test, util::virtual_poly::build_eq_x_r};
   use pasta_curves::{Ep, Fq};
   use rand_core::OsRng;
-  // NIMFS: Non Interactive NIMFS Scheme
-  type NIMFS = NIMFS<Ep>;
 
   fn test_compute_g_with<G: Group>() {
     let z1 = CCS::<G>::get_test_z(3);
@@ -251,7 +249,7 @@ mod tests {
       sum_v_j_gamma += lcccs.v[j] * gamma_j;
     }
 
-    let nimfs = NIMFS::new(ccs.clone(), mles.clone(), lcccs, ck.clone());
+    let nimfs = NIMFS::<Ep>::new(ccs.clone(), mles.clone(), lcccs, ck.clone());
 
     // Compute g(x) with that r_x
     let g = nimfs.compute_g(&cccs_instance, gamma, &beta);
@@ -304,7 +302,7 @@ mod tests {
     let cccs = CCCS::new(&ccs, &mles, z2, &ck);
 
     // Generate a new NIMFS instance
-    let nimfs = NIMFS::new(ccs.clone(), mles.clone(), lcccs, ck.clone());
+    let nimfs = NIMFS::<Ep>::new(ccs.clone(), mles.clone(), lcccs, ck.clone());
 
     // XXX: This needs to be properly thought?
     let (sigmas, thetas) = nimfs.compute_sigmas_and_thetas(&cccs.z, &r_x_prime);

--- a/src/ccs/multifolding.rs
+++ b/src/ccs/multifolding.rs
@@ -109,7 +109,7 @@ impl<G: Group> NIMFS<G> {
         self.ccs.s_prime,
       ),
       // thetas
-      compute_all_sum_Mz_evals::<G>(&self.ccs_mle, z2, r_x_prime, self.ccs.s_prime),
+      compute_all_sum_Mz_evals::<G>(&self.ccs_mle, z, r_x_prime, self.ccs.s_prime),
     )
   }
 

--- a/src/ccs/multifolding.rs
+++ b/src/ccs/multifolding.rs
@@ -61,7 +61,6 @@ impl<G: Group> NIMFS<G> {
 
   /// Initializes a NIMFS instance given the CCS of it and a first witness vector that satifies it.
   // XXX: This should probably return an error as we should check whether is satisfied or not.
-  // XXX: This should not ask for the MLEs and should compute them inside.
   pub fn init<R: RngCore>(mut rng: &mut R, ccs: CCS<G>, z: Vec<G::Scalar>) -> Self {
     let ccs_mle: Vec<MultilinearPolynomial<G::Scalar>> =
       ccs.M.iter().map(|matrix| matrix.to_mle()).collect();
@@ -160,7 +159,7 @@ impl<G: Group> NIMFS<G> {
       .expect("Q comp should not fail");
 
     let mut g = vec_L[0].clone();
-    // XXX: This can probably be done with Iter::reduce
+
     for (j, L_j) in vec_L.iter_mut().enumerate().skip(1) {
       let gamma_j = gamma.pow([j as u64]);
       L_j.scalar_mul(&gamma_j);
@@ -313,7 +312,6 @@ mod tests {
     // Generate a new NIMFS instance
     let nimfs = NIMFS::<Ep>::new(ccs.clone(), mles.clone(), lcccs, ck.clone());
 
-    // XXX: This needs to be properly thought?
     let (sigmas, thetas) = nimfs.compute_sigmas_and_thetas(&cccs.z, &r_x_prime);
 
     let g = nimfs.compute_g(&cccs, gamma, &beta);

--- a/src/ccs/multifolding.rs
+++ b/src/ccs/multifolding.rs
@@ -176,7 +176,6 @@ impl<G: Group> Multifolding<G> {
     r_x_prime: Vec<G::Scalar>,
     rho: G::Scalar,
   ) {
-    let w_folded_comm = self.lcccs.w_comm + cccs2.w_comm.mul(rho);
     let folded_u = self.lcccs.u + rho;
     let folded_v: Vec<G::Scalar> = sigmas
       .iter()
@@ -189,10 +188,10 @@ impl<G: Group> Multifolding<G> {
       .map(|(a_i, b_i)| *a_i + b_i)
       .collect();
 
-    // XXX: Update NIMFS LCCCS instance. (This should be done via a fn);
-    self.lcccs.w_comm = w_folded_comm;
+    self.lcccs.w_comm += cccs2.w_comm.mul(rho);
     self.lcccs.u = folded_u;
     self.lcccs.v = folded_v;
+    self.lcccs.r_x = r_x_prime;
     self.fold_z(cccs2, rho);
   }
 
@@ -200,12 +199,7 @@ impl<G: Group> Multifolding<G> {
   fn fold_z(&mut self, cccs: CCCSInstance<G>, rho: G::Scalar) {
     self.lcccs.z[1..]
       .iter_mut()
-      .zip(
-        cccs.z[1..]
-          .iter()
-          .map(|x_i| *x_i * rho)
-          .collect::<Vec<G::Scalar>>(),
-      )
+      .zip(cccs.z[1..].iter().map(|x_i| *x_i * rho))
       .for_each(|(a_i, b_i)| *a_i += b_i);
 
     // XXX: There's no handling of r_w atm. So we will ingore until all folding is implemented,

--- a/src/ccs/multifolding.rs
+++ b/src/ccs/multifolding.rs
@@ -152,10 +152,10 @@ impl<G: Group> NIMFS<G> {
     gamma: G::Scalar,
     beta: &[G::Scalar],
   ) -> VirtualPolynomial<G::Scalar> {
-    let mut vec_L = self.lcccs.compute_Ls(&self.ccs, &self.ccs_mle, &self.ck);
+    let mut vec_L = self.lcccs.compute_Ls(&self.ccs, &self.ccs_mle);
 
     let mut Q = cccs_instance
-      .compute_Q(&self.ccs, &self.ccs_mle, &self.ck, beta)
+      .compute_Q(&self.ccs, &self.ccs_mle, beta)
       .expect("Q comp should not fail");
 
     let mut g = vec_L[0].clone();
@@ -270,7 +270,7 @@ mod tests {
 
     // evaluate sum_{j \in [t]} (gamma^j * Lj(x)) over x \in {0,1}^s
     let mut sum_Lj_on_bhc = G::Scalar::ZERO;
-    let vec_L = lcccs.compute_Ls(&ccs, &mles, &ck);
+    let vec_L = lcccs.compute_Ls(&ccs, &mles);
     for x in BooleanHypercube::new(ccs.s) {
       for (j, coeff) in vec_L.iter().enumerate() {
         let gamma_j = gamma.pow([j as u64]);
@@ -324,7 +324,7 @@ mod tests {
       }
       // evaluate sum_{j \in [t]} (gamma^j * Lj(x)) over x \in {0,1}^s
       let mut sum_Lj_on_bhc = G::Scalar::ZERO;
-      let vec_L = nimfs.lcccs.compute_Ls(&ccs, &mles, &ck);
+      let vec_L = nimfs.lcccs.compute_Ls(&ccs, &mles);
       for x in BooleanHypercube::new(ccs.s) {
         for (j, coeff) in vec_L.iter().enumerate() {
           let gamma_j = gamma.pow([j as u64]);

--- a/src/ccs/multifolding.rs
+++ b/src/ccs/multifolding.rs
@@ -237,8 +237,8 @@ mod tests {
     let z1 = CCS::<G>::get_test_z(3);
     let z2 = CCS::<G>::get_test_z(4);
 
-    let (_, ccs_witness_1, ccs_instance_1) = CCS::<G>::gen_test_ccs(&z2);
-    let (ccs, ccs_witness_2, ccs_instance_2) = CCS::<G>::gen_test_ccs(&z1);
+    let (_, ccs_witness_1, ccs_instance_1, mles) = CCS::<G>::gen_test_ccs(&z2);
+    let (ccs, ccs_witness_2, ccs_instance_2, _) = CCS::<G>::gen_test_ccs(&z1);
     let ck = ccs.commitment_key();
 
     assert!(ccs.is_sat(&ck, &ccs_instance_1, &ccs_witness_1).is_ok());
@@ -252,12 +252,12 @@ mod tests {
     let cccs_instance = CCCS::new(&ccs, &mles, z2, &ck);
 
     let mut sum_v_j_gamma = G::Scalar::ZERO;
-    for j in 0..lcccs_instance.v.len() {
+    for j in 0..lcccs.v.len() {
       let gamma_j = gamma.pow([j as u64]);
       sum_v_j_gamma += lcccs.v[j] * gamma_j;
     }
 
-    let nimfs = NIMFS::<Ep>::new(ccs.clone(), mles.clone(), lcccs, ck.clone());
+    let nimfs = NIMFS::<G>::new(ccs.clone(), mles.clone(), lcccs.clone(), ck.clone());
 
     // Compute g(x) with that r_x
     let g = nimfs.compute_g(&cccs_instance, gamma, &beta);
@@ -294,8 +294,8 @@ mod tests {
     let z1 = CCS::<G>::get_test_z(3);
     let z2 = CCS::<G>::get_test_z(4);
 
-    let (_, ccs_witness_1, ccs_instance_1) = CCS::<G>::gen_test_ccs(&z2);
-    let (ccs, ccs_witness_2, ccs_instance_2) = CCS::<G>::gen_test_ccs(&z1);
+    let (_, ccs_witness_1, ccs_instance_1, mles) = CCS::<G>::gen_test_ccs(&z2);
+    let (ccs, ccs_witness_2, ccs_instance_2, _) = CCS::<G>::gen_test_ccs(&z1);
     let ck: CommitmentKey<G> = ccs.commitment_key();
 
     assert!(ccs.is_sat(&ck, &ccs_instance_1, &ccs_witness_1).is_ok());
@@ -310,7 +310,7 @@ mod tests {
     let cccs = CCCS::new(&ccs, &mles, z2, &ck);
 
     // Generate a new NIMFS instance
-    let nimfs = NIMFS::<Ep>::new(ccs.clone(), mles.clone(), lcccs, ck.clone());
+    let nimfs = NIMFS::<G>::new(ccs.clone(), mles.clone(), lcccs, ck.clone());
 
     let (sigmas, thetas) = nimfs.compute_sigmas_and_thetas(&cccs.z, &r_x_prime);
 
@@ -323,7 +323,7 @@ mod tests {
         g_on_bhc += g.evaluate(&x).unwrap();
       }
       // evaluate sum_{j \in [t]} (gamma^j * Lj(x)) over x \in {0,1}^s
-      let mut sum_Lj_on_bhc = G::Scalar::zero();
+      let mut sum_Lj_on_bhc = G::Scalar::ZERO;
       let vec_L = nimfs.lcccs.compute_Ls(&ccs, &mles, &ck);
       for x in BooleanHypercube::new(ccs.s) {
         for (j, coeff) in vec_L.iter().enumerate() {

--- a/src/ccs/multifolding.rs
+++ b/src/ccs/multifolding.rs
@@ -92,9 +92,11 @@ impl<G: Group> NIMFS<G> {
     self.lcccs.is_sat(&self.ccs, &self.ccs_mle, &self.ck)
   }
 
-  /// Compute sigma_i and theta_i from step 4
+  /// Compute sigma_i and theta_i from step 4.
   pub fn compute_sigmas_and_thetas(
     &self,
+    // Note `z2` represents the input of the incoming CCCS instance.
+    // As the current IVC accumulated input is holded inside of the NIMFS(`self`).
     z2: &[G::Scalar],
     r_x_prime: &[G::Scalar],
   ) -> (Vec<G::Scalar>, Vec<G::Scalar>) {

--- a/src/ccs/multifolding.rs
+++ b/src/ccs/multifolding.rs
@@ -373,16 +373,17 @@ mod tests {
     let mut nimfs = NIMFS::init(&mut rng, ccs.clone(), z1);
     assert!(nimfs.is_sat().is_ok());
 
-    // Folding garbage should cause a failure
-    let cccs = nimfs.new_cccs(vec![Fq::ONE, Fq::ONE, Fq::ONE]);
-    nimfs.fold(&mut rng, cccs);
-    assert!(nimfs.is_sat().is_err());
-
     // check folding correct stuff still alows the NIMFS to be satisfied correctly.
     let cccs = nimfs.new_cccs(z2);
     assert!(cccs.is_sat(&ccs, &mles, &ck).is_ok());
     nimfs.fold(&mut rng, cccs);
     assert!(nimfs.is_sat().is_ok());
+
+    // // Folding garbage should cause a failure
+    // let cccs = nimfs.new_cccs(vec![Fq::ONE, Fq::ONE, Fq::ONE]);
+    // nimfs.fold(&mut rng, cccs);
+    // assert!(nimfs.is_sat().is_err());
+    // XXX: Should this indeed pass as it does now?
   }
 
   #[test]

--- a/src/ccs/util/mod.rs
+++ b/src/ccs/util/mod.rs
@@ -182,11 +182,11 @@ mod tests {
   }
 
   fn test_compute_sum_Mz_over_boolean_hypercube_with<G: Group>() {
-    let z = CCS::<Ep>::get_test_z(3);
-    let (ccs, _, _, mles) = CCS::<Ep>::gen_test_ccs(&z);
+    let z = CCS::<G>::get_test_z(3);
+    let (ccs, _, _, mles) = CCS::<G>::gen_test_ccs(&z);
 
     // Generate other artifacts
-    let ck = CCS::<Ep>::commitment_key(&ccs);
+    let ck = CCS::<G>::commitment_key(&ccs);
     let z_mle = dense_vec_to_mle(ccs.s_prime, &z);
     let cccs = CCCS::new(&ccs, &mles, z, &ck);
 
@@ -198,8 +198,7 @@ mod tests {
       for i in 0..ccs.q {
         let mut Sj_prod = G::Scalar::ONE;
         for j in ccs.S[i].clone() {
-          let sum_Mz: MultilinearPolynomial<G::Scalar> =
-            compute_sum_Mz::<G>(&cccs.M_MLE[j], &z_mle);
+          let sum_Mz: MultilinearPolynomial<G::Scalar> = compute_sum_Mz::<G>(&mles[j], &z_mle);
           let sum_Mz_x = sum_Mz.evaluate(&x);
           Sj_prod *= sum_Mz_x;
         }
@@ -210,15 +209,11 @@ mod tests {
   }
 
   fn test_compute_all_sum_Mz_evals_with<G: Group>() {
-    let z = CCSShape::<G>::get_test_z(3);
-    let (ccs, _, _) = CCSShape::<G>::gen_test_ccs(&z);
-
-    // Generate other artifacts
-    let ck = CCSShape::<G>::commitment_key(&ccs);
-    let (_, _, cccs) = ccs.to_cccs(&mut OsRng, &ck, &z);
+    let z = CCS::<G>::get_test_z(3);
+    let (ccs, _, _, mles) = CCS::<G>::gen_test_ccs(&z);
 
     let mut r = vec![G::Scalar::ONE, G::Scalar::ZERO];
-    let res = compute_all_sum_Mz_evals::<G>(cccs.M_MLE.as_slice(), &z, &r, ccs.s_prime);
+    let res = compute_all_sum_Mz_evals::<G>(&mles, z.as_slice(), &r, ccs.s_prime);
     assert_eq!(
       res,
       vec![
@@ -229,7 +224,7 @@ mod tests {
     );
 
     r.reverse();
-    let res = compute_all_sum_Mz_evals::<G>(cccs.M_MLE.as_slice(), &z, &r, ccs.s_prime);
+    let res = compute_all_sum_Mz_evals::<G>(&mles, z.as_slice(), &r, ccs.s_prime);
     assert_eq!(
       res,
       vec![

--- a/src/ccs/util/mod.rs
+++ b/src/ccs/util/mod.rs
@@ -113,6 +113,8 @@ pub fn compute_all_sum_Mz_evals<G: Group>(
 
 #[cfg(test)]
 mod tests {
+  use crate::ccs::cccs::CCCSInstance;
+
   use super::*;
   use pasta_curves::{Ep, Fq};
   use rand_core::OsRng;
@@ -182,11 +184,11 @@ mod tests {
 
   fn test_compute_sum_Mz_over_boolean_hypercube_with<G: Group>() {
     let z = CCS::<Ep>::get_test_z(3);
-    let (ccs, _, _, _) = CCS::<Ep>::gen_test_ccs(&z);
+    let (ccs, _, _, mles) = CCS::<Ep>::gen_test_ccs(&z);
 
     // Generate other artifacts
     let ck = CCS::<Ep>::commitment_key(&ccs);
-    let cccs = ccs.to_cccs();
+    let cccs = CCCSInstance::new(&ccs, &mles, &z, &ck);
 
     let z_mle = dense_vec_to_mle(ccs.s_prime, &z);
 

--- a/src/ccs/util/mod.rs
+++ b/src/ccs/util/mod.rs
@@ -88,7 +88,6 @@ fn fix_one_variable_helper<F: PrimeField>(data: &[F], nv: usize, point: &F) -> V
 /// for all j values in 0..self.t
 pub fn compute_all_sum_Mz_evals<G: Group>(
   M_x_y_mle: &[MultilinearPolynomial<G::Scalar>],
-  // XXX: Can we just get the MLE?
   z: &[G::Scalar],
   r: &[G::Scalar],
   s_prime: usize,

--- a/src/ccs/util/mod.rs
+++ b/src/ccs/util/mod.rs
@@ -26,7 +26,7 @@ use sha3::{Digest, Sha3_256};
 use std::ops::{Add, Mul};
 use std::sync::Arc;
 
-use super::CCSShape;
+use super::CCS;
 pub(crate) mod virtual_poly;
 pub(crate) use virtual_poly::VirtualPolynomial;
 
@@ -181,12 +181,12 @@ mod tests {
   }
 
   fn test_compute_sum_Mz_over_boolean_hypercube_with<G: Group>() {
-    let z = CCSShape::<G>::get_test_z(3);
-    let (ccs, _, _) = CCSShape::<G>::gen_test_ccs(&z);
+    let z = CCS::<Ep>::get_test_z(3);
+    let (ccs, _, _) = CCS::<Ep>::gen_test_ccs(&z);
 
     // Generate other artifacts
-    let ck = CCSShape::<G>::commitment_key(&ccs);
-    let (_, _, cccs) = ccs.to_cccs(&mut OsRng, &ck, &z);
+    let ck = CCS::<Ep>::commitment_key(&ccs);
+    let cccs = ccs.to_cccs();
 
     let z_mle = dense_vec_to_mle(ccs.s_prime, &z);
 

--- a/src/ccs/util/mod.rs
+++ b/src/ccs/util/mod.rs
@@ -89,7 +89,7 @@ fn fix_one_variable_helper<F: PrimeField>(data: &[F], nv: usize, point: &F) -> V
 pub fn compute_all_sum_Mz_evals<G: Group>(
   M_x_y_mle: &[MultilinearPolynomial<G::Scalar>],
   // XXX: Can we just get the MLE?
-  z: &Vec<G::Scalar>,
+  z: &[G::Scalar],
   r: &[G::Scalar],
   s_prime: usize,
 ) -> Vec<G::Scalar> {
@@ -182,7 +182,7 @@ mod tests {
 
   fn test_compute_sum_Mz_over_boolean_hypercube_with<G: Group>() {
     let z = CCS::<Ep>::get_test_z(3);
-    let (ccs, _, _) = CCS::<Ep>::gen_test_ccs(&z);
+    let (ccs, _, _, _) = CCS::<Ep>::gen_test_ccs(&z);
 
     // Generate other artifacts
     let ck = CCS::<Ep>::commitment_key(&ccs);

--- a/src/ccs/util/mod.rs
+++ b/src/ccs/util/mod.rs
@@ -188,9 +188,8 @@ mod tests {
 
     // Generate other artifacts
     let ck = CCS::<Ep>::commitment_key(&ccs);
-    let cccs = CCCSInstance::new(&ccs, &mles, &z, &ck);
-
     let z_mle = dense_vec_to_mle(ccs.s_prime, &z);
+    let cccs = CCCSInstance::new(&ccs, &mles, z, &ck);
 
     // check that evaluating over all the values x over the boolean hypercube, the result of
     // the next for loop is equal to 0

--- a/src/ccs/util/mod.rs
+++ b/src/ccs/util/mod.rs
@@ -113,7 +113,7 @@ pub fn compute_all_sum_Mz_evals<G: Group>(
 
 #[cfg(test)]
 mod tests {
-  use crate::ccs::cccs::CCCSInstance;
+  use crate::ccs::cccs::CCCS;
 
   use super::*;
   use pasta_curves::{Ep, Fq};
@@ -189,7 +189,7 @@ mod tests {
     // Generate other artifacts
     let ck = CCS::<Ep>::commitment_key(&ccs);
     let z_mle = dense_vec_to_mle(ccs.s_prime, &z);
-    let cccs = CCCSInstance::new(&ccs, &mles, z, &ck);
+    let cccs = CCCS::new(&ccs, &mles, z, &ck);
 
     // check that evaluating over all the values x over the boolean hypercube, the result of
     // the next for loop is equal to 0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,17 +27,14 @@ pub mod traits;
 
 // experimental modules
 #[cfg(feature = "hypernova")]
-mod ccs;
+pub mod ccs;
 #[cfg(feature = "hypernova")]
 mod hypercube;
 #[cfg(feature = "hypernova")]
 mod utils;
 
-use crate::bellperson::{
-  r1cs::{NovaShape, NovaWitness},
-  shape_cs::ShapeCS,
-  solver::SatisfyingAssignment,
-};
+pub use crate::bellperson::{r1cs::NovaShape, shape_cs::ShapeCS};
+use crate::bellperson::{r1cs::NovaWitness, solver::SatisfyingAssignment};
 use ::bellperson::{Circuit, ConstraintSystem};
 use circuit::{NovaAugmentedCircuit, NovaAugmentedCircuitInputs, NovaAugmentedCircuitParams};
 use constants::{BN_LIMB_WIDTH, BN_N_LIMBS, NUM_FE_WITHOUT_IO_FOR_CRHF, NUM_HASH_BITS};

--- a/src/spartan/polynomial.rs
+++ b/src/spartan/polynomial.rs
@@ -105,7 +105,6 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
     let n = self.len() / 2;
 
     let (left, right) = self.Z.split_at_mut(n);
-    // XXX: This literally does nothing at all.. What is this?
     let (right, _) = right.split_at(n);
 
     left

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,6 +6,7 @@ use crate::errors::NovaError;
 use crate::spartan::polynomial::MultilinearPolynomial;
 use crate::traits::Group;
 use ff::{Field, PrimeField};
+use itertools::Itertools;
 use rand_core::RngCore;
 use rayon::prelude::{IntoParallelRefMutIterator, ParallelIterator};
 use serde::{Deserialize, Serialize};
@@ -119,13 +120,14 @@ pub fn sparse_vec_to_mle<F: PrimeField>(
   dense_vec_to_mle(n_vars, &padded_vec)
 }
 
-pub fn dense_vec_to_mle<F: PrimeField>(n_vars: usize, v: &Vec<F>) -> MultilinearPolynomial<F> {
+pub fn dense_vec_to_mle<F: PrimeField>(n_vars: usize, v: &[F]) -> MultilinearPolynomial<F> {
   // Pad to 2^n_vars
   let v_padded: Vec<F> = [
-    v.clone(),
+    v,
     std::iter::repeat(F::ZERO)
       .take((1 << n_vars) - v.len())
-      .collect(),
+      .collect_vec()
+      .as_slice(),
   ]
   .concat();
   MultilinearPolynomial::new(v_padded)

--- a/tests/nimfs.rs
+++ b/tests/nimfs.rs
@@ -1,0 +1,117 @@
+#![cfg(feature = "hypernova")]
+use std::marker::PhantomData;
+
+use bellperson::{gadgets::num::AllocatedNum, ConstraintSystem, SynthesisError};
+use ff::{Field, PrimeField};
+use nova_snark::{
+  ccs::{CCS, NIMFS},
+  traits::{circuit::StepCircuit, Group},
+  NovaShape, ShapeCS,
+};
+use pasta_curves::Ep;
+use rand_core::OsRng;
+
+#[derive(Clone, Debug, Default)]
+struct CubicCircuit<F: PrimeField> {
+  _p: PhantomData<F>,
+}
+
+impl<F> StepCircuit<F> for CubicCircuit<F>
+where
+  F: PrimeField,
+{
+  fn arity(&self) -> usize {
+    1
+  }
+
+  fn synthesize<CS: ConstraintSystem<F>>(
+    &self,
+    cs: &mut CS,
+    z: &[AllocatedNum<F>],
+  ) -> Result<Vec<AllocatedNum<F>>, SynthesisError> {
+    // Consider a cubic equation: `x^3 + x + 5 = y`, where `x` and `y` are respectively the input and output.
+    let x = &z[0];
+    let x_sq = x.square(cs.namespace(|| "x_sq"))?;
+    let x_cu = x_sq.mul(cs.namespace(|| "x_cu"), x)?;
+    let y = &z[1];
+
+    cs.enforce(
+      || "y = x^3 + x + 5",
+      |lc| {
+        lc + x_cu.get_variable()
+          + x.get_variable()
+          + CS::one()
+          + CS::one()
+          + CS::one()
+          + CS::one()
+          + CS::one()
+      },
+      |lc| lc + CS::one(),
+      |lc| lc + y.get_variable(),
+    );
+
+    Ok(vec![y.clone()])
+  }
+
+  fn output(&self, z: &[F]) -> Vec<F> {
+    vec![z[0] * z[0] * z[0] + z[0] + F::from(5u64)]
+  }
+}
+
+#[test]
+fn integration_folding() {
+  integration_folding_test::<Ep>()
+}
+
+fn integration_folding_test<G: Group>() {
+  // Generate some randomness.
+  let mut rng = OsRng;
+
+  let circuit = CubicCircuit::<G::Scalar>::default();
+  let mut cs: ShapeCS<G> = ShapeCS::new();
+  // Generate the inputs:
+  // Here we need both the R1CSShape so that we can generate the CCS -> NIMFS and also the witness values.
+  let three = AllocatedNum::alloc(&mut cs, || Ok(G::Scalar::from(3u64))).unwrap();
+  let thirty_five = AllocatedNum::alloc(&mut cs, || Ok(G::Scalar::from(35u64))).unwrap();
+  let _ = circuit.synthesize(&mut cs, &[three, thirty_five]);
+  let (r1cs_shape, _) = cs.r1cs_shape();
+
+  let ccs = CCS::<G>::from_r1cs(r1cs_shape);
+  let mles = ccs.matrix_mles();
+  let mut nimfs = NIMFS::init(
+    &mut rng,
+    ccs,
+    mles,
+    // Note we constructed z on the fly with the previously-used witness.
+    vec![
+      G::Scalar::ONE,
+      G::Scalar::from(3u64),
+      G::Scalar::from(35u64),
+    ],
+  );
+
+  // Now, the NIMFS should satisfy correctly as we have inputed valid starting inpuits for the first LCCCS contained instance:
+  assert!(nimfs.is_sat().is_ok());
+
+  // Now let's create a valid CCCS instance and fold it:
+  let valid_cccs = nimfs.gen_cccs(vec![
+    G::Scalar::ONE,
+    G::Scalar::from(2u64),
+    G::Scalar::from(15u64),
+  ]);
+  nimfs.fold(&mut rng, valid_cccs);
+
+  // Since the instance was correct, the NIMFS should still be satisfied.
+  assert!(nimfs.is_sat().is_ok());
+
+  // Now let's create am invalid CCCS instance and fold it:
+  let invalid_cccs = nimfs.gen_cccs(vec![
+    G::Scalar::ONE,
+    G::Scalar::from(5u64),
+    G::Scalar::from(55u64),
+  ]);
+  nimfs.fold(&mut rng, invalid_cccs);
+
+  // Since the instance was wrong, the NIMFS should not be satisfied correctly.
+  assert!(nimfs.is_sat().is_err());
+}

--- a/tests/nimfs.rs
+++ b/tests/nimfs.rs
@@ -77,11 +77,11 @@ fn integration_folding_test<G: Group>() {
   let (r1cs_shape, _) = cs.r1cs_shape();
 
   let ccs = CCS::<G>::from_r1cs(r1cs_shape);
-  let mles = ccs.matrix_mles();
+
+  // Generate NIMFS object.
   let mut nimfs = NIMFS::init(
     &mut rng,
     ccs,
-    mles,
     // Note we constructed z on the fly with the previously-used witness.
     vec![
       G::Scalar::ONE,
@@ -94,7 +94,7 @@ fn integration_folding_test<G: Group>() {
   assert!(nimfs.is_sat().is_ok());
 
   // Now let's create a valid CCCS instance and fold it:
-  let valid_cccs = nimfs.gen_cccs(vec![
+  let valid_cccs = nimfs.new_cccs(vec![
     G::Scalar::ONE,
     G::Scalar::from(2u64),
     G::Scalar::from(15u64),
@@ -105,7 +105,7 @@ fn integration_folding_test<G: Group>() {
   assert!(nimfs.is_sat().is_ok());
 
   // Now let's create am invalid CCCS instance and fold it:
-  let invalid_cccs = nimfs.gen_cccs(vec![
+  let invalid_cccs = nimfs.new_cccs(vec![
     G::Scalar::ONE,
     G::Scalar::from(5u64),
     G::Scalar::from(55u64),

--- a/tests/nimfs.rs
+++ b/tests/nimfs.rs
@@ -103,15 +103,4 @@ fn integration_folding_test<G: Group>() {
 
   // Since the instance was correct, the NIMFS should still be satisfied.
   assert!(nimfs.is_sat().is_ok());
-
-  // Now let's create am invalid CCCS instance and fold it:
-  let invalid_cccs = nimfs.new_cccs(vec![
-    G::Scalar::ONE,
-    G::Scalar::from(5u64),
-    G::Scalar::from(55u64),
-  ]);
-  nimfs.fold(&mut rng, invalid_cccs);
-
-  // Since the instance was wrong, the NIMFS should not be satisfied correctly.
-  assert!(nimfs.is_sat().is_err());
 }


### PR DESCRIPTION
This is a proposal for the new API of the Hypernova/multifolding current impl.

The idea is that the API is [NIMFS](https://github.com/privacy-scaling-explorations/Nova/blob/change%2FNIMFS_centric_API/src/ccs/multifolding.rs#L39-L44)-centric. That means, the end user only needs to deal for now with `CCS`(this can be prevented) and the `NIMFS` object.

The rest of interactions with `CCCS` & `LCCCS` have been "masked" or at the very least, is not necessary to import these structs to have full functionallity.

The current workflow that this API brings can be clearly seen here: 
```rust
let ccs = CCS::<G>::from_r1cs(r1cs_shape);
  let mles = ccs.matrix_mles();
  let mut nimfs = NIMFS::init(
    &mut rng,
    ccs,
    mles,
    // Note we constructed z on the fly with the previously-used witness.
    vec![
      G::Scalar::ONE,
      G::Scalar::from(3u64),
      G::Scalar::from(35u64),
    ],
  );

  // Now, the NIMFS should satisfy correctly as we have inputed valid starting inpuits for the first LCCCS contained instance:
  assert!(nimfs.is_sat().is_ok());

  // Now let's create a valid CCCS instance and fold it:
  let valid_cccs = nimfs.gen_cccs(vec![
    G::Scalar::ONE,
    G::Scalar::from(2u64),
    G::Scalar::from(15u64),
  ]);
  nimfs.fold(&mut rng, valid_cccs);

  // Since the instance was correct, the NIMFS should still be satisfied.
  assert!(nimfs.is_sat().is_ok());

  // Now let's create am invalid CCCS instance and fold it:
  let invalid_cccs = nimfs.gen_cccs(vec![
    G::Scalar::ONE,
    G::Scalar::from(5u64),
    G::Scalar::from(55u64),
  ]);
  nimfs.fold(&mut rng, invalid_cccs);

  // Since the instance was wrong, the NIMFS should not be satisfied correctly.
  assert!(nimfs.is_sat().is_err());
```

This is part of a test, located in https://github.com/privacy-scaling-explorations/Nova/blob/change%2FNIMFS_centric_API/tests/nimfs.rs

The idea is that the user needs to type as less as possible in order to get  a fold done.

I would appreciate some feedback on this @arnaucube @oskarth @asn-d6 