### PR TITLE
Use polynomial.rs instead of virtual_poly for equality polynomial

### DIFF
--- a/src/ccs/cccs.rs
+++ b/src/ccs/cccs.rs
@@ -109,9 +109,9 @@ impl<G: Group> CCCS<G> {
   ) -> Result<VirtualPolynomial<G::Scalar>, NovaError> {
     // XXX:     let q = self.compute_q(ccs, ccs_mles)?;
     let q = self.compute_q(z)?;
-    // let qfhat_old = q.build_f_hat_old(beta);
+    let qfhat_old = q.build_f_hat_old(beta);
     let qfhat_new = q.build_f_hat(beta);
-    // dbg!(qfhat_old.clone());
+    dbg!(qfhat_old.clone());
     dbg!(qfhat_new.clone());
 
     qfhat_new

--- a/src/ccs/cccs.rs
+++ b/src/ccs/cccs.rs
@@ -109,12 +109,7 @@ impl<G: Group> CCCS<G> {
   ) -> Result<VirtualPolynomial<G::Scalar>, NovaError> {
     // XXX:     let q = self.compute_q(ccs, ccs_mles)?;
     let q = self.compute_q(z)?;
-    let qfhat_old = q.build_f_hat_old(beta);
-    let qfhat_new = q.build_f_hat(beta);
-    dbg!(qfhat_old.clone());
-    dbg!(qfhat_new.clone());
-
-    qfhat_new
+    q.build_f_hat(beta)
   }
 
   /// Perform the check of the CCCS instance described at section 4.1

--- a/src/ccs/cccs.rs
+++ b/src/ccs/cccs.rs
@@ -109,9 +109,9 @@ impl<G: Group> CCCS<G> {
   ) -> Result<VirtualPolynomial<G::Scalar>, NovaError> {
     // XXX:     let q = self.compute_q(ccs, ccs_mles)?;
     let q = self.compute_q(z)?;
-    let qfhat_old = q.build_f_hat_old(beta);
+    // let qfhat_old = q.build_f_hat_old(beta);
     let qfhat_new = q.build_f_hat(beta);
-    dbg!(qfhat_old.clone());
+    // dbg!(qfhat_old.clone());
     dbg!(qfhat_new.clone());
 
     qfhat_new

--- a/src/ccs/cccs.rs
+++ b/src/ccs/cccs.rs
@@ -107,8 +107,7 @@ impl<G: Group> CCCS<G> {
     ccs_mles: &[MultilinearPolynomial<G::Scalar>],
     beta: &[G::Scalar],
   ) -> Result<VirtualPolynomial<G::Scalar>, NovaError> {
-    // XXX:     let q = self.compute_q(ccs, ccs_mles)?;
-    let q = self.compute_q(z)?;
+    let q = self.compute_q(ccs, ccs_mles)?;
     q.build_f_hat(beta)
   }
 

--- a/src/ccs/cccs.rs
+++ b/src/ccs/cccs.rs
@@ -107,8 +107,14 @@ impl<G: Group> CCCS<G> {
     ccs_mles: &[MultilinearPolynomial<G::Scalar>],
     beta: &[G::Scalar],
   ) -> Result<VirtualPolynomial<G::Scalar>, NovaError> {
-    let q = self.compute_q(ccs, ccs_mles)?;
-    q.build_f_hat(beta)
+    // XXX:     let q = self.compute_q(ccs, ccs_mles)?;
+    let q = self.compute_q(z)?;
+    let qfhat_old = q.build_f_hat_old(beta);
+    let qfhat_new = q.build_f_hat(beta);
+    dbg!(qfhat_old.clone());
+    dbg!(qfhat_new.clone());
+
+    qfhat_new
   }
 
   /// Perform the check of the CCCS instance described at section 4.1

--- a/src/ccs/multifolding.rs
+++ b/src/ccs/multifolding.rs
@@ -279,10 +279,6 @@ mod tests {
     // evaluating g(x) over the boolean hypercube should give the same result as evaluating the
     // sum of gamma^j * v_j over j \in [t]
 
-    // XXX: This fails, order of evaluations different for these two
-    dbg!(g_on_bhc);
-    dbg!(sum_v_j_gamma);
-
     assert_eq!(g_on_bhc, sum_v_j_gamma);
   }
 

--- a/src/ccs/multifolding.rs
+++ b/src/ccs/multifolding.rs
@@ -124,8 +124,7 @@ impl<G: Group> NIMFS<G> {
   ) -> G::Scalar {
     let mut c = G::Scalar::ZERO;
 
-    // XXX:     let e1 = eq_eval(&self.lcccs.r_x, r_x_prime);
-    let e1 = EqPolynomial::new(r_x.to_vec()).evaluate(r_x_prime);
+    let e1 = EqPolynomial::new(self.lcccs.r_x.to_vec()).evaluate(r_x_prime);
     let e2 = EqPolynomial::new(beta.to_vec()).evaluate(r_x_prime);
 
     // (sum gamma^j * e1 * sigma_j)

--- a/src/ccs/multifolding.rs
+++ b/src/ccs/multifolding.rs
@@ -277,7 +277,6 @@ mod tests {
 
     // evaluating g(x) over the boolean hypercube should give the same result as evaluating the
     // sum of gamma^j * v_j over j \in [t]
-
     assert_eq!(g_on_bhc, sum_v_j_gamma);
   }
 

--- a/src/ccs/multifolding.rs
+++ b/src/ccs/multifolding.rs
@@ -5,7 +5,7 @@ use super::{CCSWitness, CCS};
 use crate::ccs::util::compute_all_sum_Mz_evals;
 use crate::hypercube::BooleanHypercube;
 use crate::spartan::math::Math;
-use crate::spartan::polynomial::MultilinearPolynomial;
+use crate::spartan::polynomial::{EqPolynomial, MultilinearPolynomial};
 use crate::{
   constants::{BN_LIMB_WIDTH, BN_N_LIMBS, NUM_FE_FOR_RO, NUM_HASH_BITS},
   errors::NovaError,
@@ -124,8 +124,9 @@ impl<G: Group> NIMFS<G> {
   ) -> G::Scalar {
     let mut c = G::Scalar::ZERO;
 
-    let e1 = eq_eval(&self.lcccs.r_x, r_x_prime);
-    let e2 = eq_eval(beta, r_x_prime);
+    // XXX:     let e1 = eq_eval(&self.lcccs.r_x, r_x_prime);
+    let e1 = EqPolynomial::new(r_x.to_vec()).evaluate(r_x_prime);
+    let e2 = EqPolynomial::new(beta.to_vec()).evaluate(r_x_prime);
 
     // (sum gamma^j * e1 * sigma_j)
     for (j, sigma_j) in sigmas.iter().enumerate() {
@@ -214,18 +215,6 @@ impl<G: Group> NIMFS<G> {
     // XXX: There's no handling of r_w atm. So we will ingore until all folding is implemented,
     // let r_w = w1.r_w + rho * w2.r_w;
   }
-}
-
-/// Evaluate eq polynomial.
-pub fn eq_eval<F: PrimeField>(x: &[F], y: &[F]) -> F {
-  assert_eq!(x.len(), y.len());
-
-  let mut res = F::ONE;
-  for (&xi, &yi) in x.iter().zip(y.iter()) {
-    let xi_yi = xi * yi;
-    res *= xi_yi + xi_yi - xi - yi + F::ONE;
-  }
-  res
 }
 
 #[cfg(test)]

--- a/src/ccs/multifolding.rs
+++ b/src/ccs/multifolding.rs
@@ -220,7 +220,7 @@ impl<G: Group> NIMFS<G> {
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::ccs::{test, util::virtual_poly::build_eq_x_r};
+  use crate::ccs::test;
   use pasta_curves::{Ep, Fq};
   use rand_core::OsRng;
 
@@ -278,6 +278,11 @@ mod tests {
 
     // evaluating g(x) over the boolean hypercube should give the same result as evaluating the
     // sum of gamma^j * v_j over j \in [t]
+
+    // XXX: This fails, order of evaluations different for these two
+    dbg!(g_on_bhc);
+    dbg!(sum_v_j_gamma);
+
     assert_eq!(g_on_bhc, sum_v_j_gamma);
   }
 

--- a/src/ccs/util/virtual_poly.rs
+++ b/src/ccs/util/virtual_poly.rs
@@ -29,36 +29,11 @@ use std::collections::HashMap;
 use std::ops::{Add, Mul};
 use std::sync::Arc;
 
-/// Generates a permutation vector for a size `n` by reversing binary indices.
-fn generate_permutation(n: usize) -> Vec<usize> {
-  (0..n)
-    .map(|i| {
-      let log_n = (n as f64).log2() as usize; // number of bits needed for the index
-      let mut res = 0;
-      for j in 0..log_n {
-        let bit = (i >> j) & 1;
-        res |= bit << (log_n - 1 - j);
-      }
-      res
-    })
-    .collect()
-}
-
-/// Reorders a vector based on a given permutation vector.
-fn reorder_vector<F: Clone>(vec: &mut Vec<F>, permutation: &Vec<usize>) {
-  let mut temp = vec.clone();
-  for (i, &index) in permutation.iter().enumerate() {
-    temp[i] = vec[index].clone();
-  }
-  *vec = temp;
-}
-
-// A bit of collage-programming here.
-// As a tmp way to have multilinear polynomial product+addition.
+// NOTE: This is a temporary solution to have multilinear polynomial product+addition.
 // The idea is to re-evaluate once everything works and decide if we replace this code
 // by something else.
 //
-// THIS CODE HAS BEEN TAKEN FpOM THE ESPRESSO SYSTEMS LIB:
+// THIS CODE HAS BEEN TAKEN FROM THE ESPRESSO SYSTEMS LIB AND ADAPTED TO OUR NEEDS.:
 // <https://github.com/EspressoSystems/hyperplonk/blob/main/arithmetic/src/virtual_polynomial.rs#L22-L332>
 //
 #[rustfmt::skip]
@@ -317,19 +292,6 @@ impl<F: PrimeField> VirtualPolynomial<F> {
     Ok(poly)
   }
 
-  // XXX: Remove me, temp for debugging
-  pub fn build_f_hat_old(&self, r: &[F]) -> Result<Self, NovaError> {
-    if self.aux_info.num_variables != r.len() {
-      return Err(NovaError::VpArith);
-    }
-
-    let eq_x_r_old = build_eq_x_r(r)?;
-    let mut res = self.clone();
-    res.mul_by_mle(eq_x_r_old, F::ONE)?;
-
-    Ok(res)
-  }
-
   // Input poly f(x) and a random vector r, output
   //      \hat f(x) = \sum_{x_i \in eval_x} f(x_i) eq(x, r)
   // where
@@ -341,30 +303,10 @@ impl<F: PrimeField> VirtualPolynomial<F> {
       return Err(NovaError::VpArith);
     }
 
-    // Old version of eq_x_r using `virtual_poly.rs`
-    let eq_x_r_old = build_eq_x_r(r)?;
-
-    // New version of eq_x_r using `polynomial.rs`
-    let eq_polynomial = EqPolynomial::new(r.to_vec());
-    let mut evaluations = eq_polynomial.evals();
-
-    // Re-orders the evaluations to match endianness of VirtualPoly
-    //
-    // NOTE: We probably want to benchmark this,
-    // but given that numbers of evaluations is small it might not be that bad
-    let n = evaluations.len();
-    let permutation = generate_permutation(n);
-    reorder_vector(&mut evaluations, &permutation);
-
-    dbg!(evaluations.clone());
-    let multilinear_poly = MultilinearPolynomial::new(evaluations);
-    let eq_x_r_new = Arc::new(multilinear_poly);
-
-    dbg!(eq_x_r_old.Z.clone());
-    dbg!(eq_x_r_new.Z.clone());
+    let eq_x_r = build_eq_x_r(r)?;
 
     let mut res = self.clone();
-    res.mul_by_mle(eq_x_r_new, F::ONE)?;
+    res.mul_by_mle(eq_x_r, F::ONE)?;
 
     Ok(res)
   }
@@ -377,77 +319,43 @@ impl<F: PrimeField> VirtualPolynomial<F> {
 /// over r, which is
 ///      eq(x,y) = \prod_i=1^num_var (x_i * r_i + (1-x_i)*(1-r_i))
 pub fn build_eq_x_r<F: PrimeField>(r: &[F]) -> Result<Arc<MultilinearPolynomial<F>>, NovaError> {
-  let evals = build_eq_x_r_vec(r)?;
+  let eq_polynomial = EqPolynomial::new(r.to_vec());
+  let mut evaluations = eq_polynomial.evals();
 
-  let mle = MultilinearPolynomial::new(evals);
+  // Re-orders the evaluations to match endianness of VirtualPoly
+  //
+  // NOTE: We probably want to benchmark this,
+  // but given that numbers of evaluations is small it might not be that bad
+  let permutation = generate_permutation(evaluations.len());
+  reorder_vector(&mut evaluations, &permutation);
+
+  let mle = MultilinearPolynomial::new(evaluations);
 
   Ok(Arc::new(mle))
 }
 
-/// This function build the eq(x, r) polynomial for any given r, and output the
-/// evaluation of eq(x, r) in its vector form.
-///
-/// Evaluate
-///      eq(x,y) = \prod_i=1^num_var (x_i * y_i + (1-x_i)*(1-y_i))
-/// over r, which is
-///      eq(x,y) = \prod_i=1^num_var (x_i * r_i + (1-x_i)*(1-r_i))
-pub fn build_eq_x_r_vec<F: PrimeField>(r: &[F]) -> Result<Vec<F>, NovaError> {
-  // we build eq(x,r) Fpom its evaluations
-  // we want to evaluate eq(x,r) over x \in {0, 1}^num_vars
-  // for example, with num_vars = 4, x is a binary vector of 4, then
-  //  0 0 0 0 -> (1-r0)   * (1-r1)    * (1-r2)    * (1-r3)
-  //  1 0 0 0 -> r0       * (1-r1)    * (1-r2)    * (1-r3)
-  //  0 1 0 0 -> (1-r0)   * r1        * (1-r2)    * (1-r3)
-  //  1 1 0 0 -> r0       * r1        * (1-r2)    * (1-r3)
-  //  ....
-  //  1 1 1 1 -> r0       * r1        * r2        * r3
-  // we will need 2^num_var evaluations
-
-  let mut eval = Vec::new();
-  build_eq_x_r_helper(r, &mut eval)?;
-
-  Ok(eval)
+/// Generates a permutation vector for a size `n` by reversing binary indices.
+fn generate_permutation(n: usize) -> Vec<usize> {
+  (0..n)
+    .map(|i| {
+      let log_n = (n as f64).log2() as usize; // number of bits needed for the index
+      let mut res = 0;
+      for j in 0..log_n {
+        let bit = (i >> j) & 1;
+        res |= bit << (log_n - 1 - j);
+      }
+      res
+    })
+    .collect()
 }
 
-/// A helper function to build eq(x, r) recursively.
-/// This function takes `r.len()` steps, and for each step it requires a maximum
-/// `r.len()-1` multiplications.
-fn build_eq_x_r_helper<F: PrimeField>(r: &[F], buf: &mut Vec<F>) -> Result<(), NovaError> {
-  if r.is_empty() {
-    return Err(NovaError::VpArith);
-  } else if r.len() == 1 {
-    // initializing the buffer with [1-r_0, r_0]
-    buf.push(F::ONE - r[0]);
-    buf.push(r[0]);
-  } else {
-    build_eq_x_r_helper(&r[1..], buf)?;
-
-    // suppose at the previous step we received [b_1, ..., b_k]
-    // for the current step we will need
-    // if x_0 = 0:   (1-r0) * [b_1, ..., b_k]
-    // if x_0 = 1:   r0 * [b_1, ..., b_k]
-    // let mut res = vec![];
-    // for &b_i in buf.iter() {
-    //     let tmp = r[0] * b_i;
-    //     res.push(b_i - tmp);
-    //     res.push(tmp);
-    // }
-    // *buf = res;
-
-    let mut res = vec![F::ZERO; buf.len() << 1];
-    res.par_iter_mut().enumerate().for_each(|(i, val)| {
-      let bi = buf[i >> 1];
-      let tmp = r[0] * bi;
-      if i & 1 == 0 {
-        *val = bi - tmp;
-      } else {
-        *val = tmp;
-      }
-    });
-    *buf = res;
+/// Reorders a vector based on a given permutation vector.
+fn reorder_vector<F: Clone>(vec: &mut Vec<F>, permutation: &[usize]) {
+  let mut temp = vec.clone();
+  for (i, &index) in permutation.iter().enumerate() {
+    temp[i] = vec[index].clone();
   }
-
-  Ok(())
+  *vec = temp;
 }
 
 #[cfg(test)]
@@ -554,81 +462,47 @@ mod test {
 
     Arc::new(mle)
   }
-}
 
-#[cfg(test)]
-mod tests {
-  use super::*;
-  use pasta_curves::Fq;
-  use rand_core::OsRng;
+  #[cfg(test)]
+  mod tests {
+    use super::*;
+    use pasta_curves::Fq;
+    use rand_core::OsRng;
 
-  #[test]
-  fn test_generate_permutation() {
-    assert_eq!(generate_permutation(2), vec![0, 1]);
-    assert_eq!(generate_permutation(4), vec![0, 2, 1, 3]);
-    assert_eq!(generate_permutation(8), vec![0, 4, 2, 6, 1, 5, 3, 7]);
-  }
+    #[test]
+    fn test_generate_permutation() {
+      assert_eq!(generate_permutation(2), vec![0, 1]);
+      assert_eq!(generate_permutation(4), vec![0, 2, 1, 3]);
+      assert_eq!(generate_permutation(8), vec![0, 4, 2, 6, 1, 5, 3, 7]);
+    }
 
-  #[test]
-  fn test_reorder_vector() {
-    let mut vec = vec![10, 20, 30, 40, 50, 60, 70, 80];
-    let permutation = vec![0, 4, 2, 6, 1, 5, 3, 7];
-    reorder_vector(&mut vec, &permutation);
-    assert_eq!(vec, vec![10, 50, 30, 70, 20, 60, 40, 80]);
-  }
+    #[test]
+    fn test_reorder_vector() {
+      let mut vec = vec![10, 20, 30, 40, 50, 60, 70, 80];
+      let permutation = vec![0, 4, 2, 6, 1, 5, 3, 7];
+      reorder_vector(&mut vec, &permutation);
+      assert_eq!(vec, vec![10, 50, 30, 70, 20, 60, 40, 80]);
+    }
 
-  #[test]
-  fn test_build_f_hat() {
-    let mut rng = OsRng;
-    let num_vars = 3; // You can change this value according to your requirement
+    #[test]
+    fn test_build_f_hat() {
+      let mut rng = OsRng;
+      let num_vars = 3; // You can change this value according to your requirement
 
-    // Create a VirtualPolynomial
-    let poly = VirtualPolynomial::<Fq>::new(num_vars);
-    let r: Vec<Fq> = (0..num_vars).map(|_| Fq::random(&mut rng)).collect();
-
-    // Test with correct input length
-    let result = poly.build_f_hat(&r);
-    assert!(result.is_ok(), "Failed with correct input length");
-
-    // Test with incorrect input length
-    let bad_r: Vec<Fq> = (0..num_vars + 1).map(|_| Fq::random(&mut rng)).collect();
-    let result = poly.build_f_hat(&bad_r);
-    assert!(
-      matches!(result, Err(NovaError::VpArith)),
-      "Did not fail with incorrect input length"
-    );
-  }
-
-  #[test]
-  fn test_eq_x_r_equality() {
-    let mut rng = OsRng;
-
-    for num_vars in 1..=3 {
-      // Generate random inputs
+      // Create a VirtualPolynomial
+      let poly = VirtualPolynomial::<Fq>::new(num_vars);
       let r: Vec<Fq> = (0..num_vars).map(|_| Fq::random(&mut rng)).collect();
 
-      // Old version of eq_x_r using `virtual_poly.rs`
-      let eq_x_r_old = build_eq_x_r(&r).unwrap().clone();
+      // Test with correct input length
+      let result = poly.build_f_hat(&r);
+      assert!(result.is_ok(), "Failed with correct input length");
 
-      // New version of eq_x_r using `polynomial.rs`
-      let eq_polynomial = EqPolynomial::new(r.to_vec());
-      let mut evaluations = eq_polynomial.evals();
-
-      let n = evaluations.len();
-      let permutation = generate_permutation(n);
-      reorder_vector(&mut evaluations, &permutation);
-
-      let multilinear_poly = MultilinearPolynomial::new(evaluations);
-      let eq_x_r_new = Arc::new(multilinear_poly);
-
-      dbg!(eq_x_r_old.Z.clone());
-      dbg!(eq_x_r_new.Z.clone());
-
-      // Check equality of the results
-      assert_eq!(
-        eq_x_r_old.Z, eq_x_r_new.Z,
-        "eq_x_r_old.Z and eq_x_r.Z outputs are not equal for num_vars = {}",
-        num_vars
+      // Test with incorrect input length
+      let bad_r: Vec<Fq> = (0..num_vars + 1).map(|_| Fq::random(&mut rng)).collect();
+      let result = poly.build_f_hat(&bad_r);
+      assert!(
+        matches!(result, Err(NovaError::VpArith)),
+        "Did not fail with incorrect input length"
       );
     }
   }

--- a/src/ccs/util/virtual_poly.rs
+++ b/src/ccs/util/virtual_poly.rs
@@ -294,17 +294,17 @@ impl<F: PrimeField> VirtualPolynomial<F> {
   }
 
   // XXX: Remove me, temp for debugging
-  pub fn build_f_hat_old(&self, r: &[F]) -> Result<Self, NovaError> {
-    if self.aux_info.num_variables != r.len() {
-      return Err(NovaError::VpArith);
-    }
+  // pub fn build_f_hat_old(&self, r: &[F]) -> Result<Self, NovaError> {
+  //   if self.aux_info.num_variables != r.len() {
+  //     return Err(NovaError::VpArith);
+  //   }
 
-    let eq_x_r_old = build_eq_x_r(r)?;
-    let mut res = self.clone();
-    res.mul_by_mle(eq_x_r_old, F::ONE)?;
+  //   let eq_x_r_old = build_eq_x_r(r)?;
+  //   let mut res = self.clone();
+  //   res.mul_by_mle(eq_x_r_old, F::ONE)?;
 
-    Ok(res)
-  }
+  //   Ok(res)
+  // }
 
   // Input poly f(x) and a random vector r, output
   //      \hat f(x) = \sum_{x_i \in eval_x} f(x_i) eq(x, r)
@@ -330,7 +330,7 @@ impl<F: PrimeField> VirtualPolynomial<F> {
     // See `build_eq_x_r_helper` helper below
 
     // Old version of eq_x_r using `virtual_poly.rs`
-    let eq_x_r_old = build_eq_x_r(r)?;
+    // let eq_x_r_old = build_eq_x_r(r)?;
 
     // New version of eq_x_r using `polynomial.rs`
     let eq_polynomial = EqPolynomial::new(r.to_vec());
@@ -338,7 +338,7 @@ impl<F: PrimeField> VirtualPolynomial<F> {
     let multilinear_poly = MultilinearPolynomial::new(evaluations);
     let eq_x_r_new = Arc::new(multilinear_poly);
 
-    dbg!(eq_x_r_old.Z.clone());
+    // dbg!(eq_x_r_old.Z.clone());
     dbg!(eq_x_r_new.Z.clone());
 
     let mut res = self.clone();
@@ -354,13 +354,13 @@ impl<F: PrimeField> VirtualPolynomial<F> {
 ///      eq(x,y) = \prod_i=1^num_var (x_i * y_i + (1-x_i)*(1-y_i))
 /// over r, which is
 ///      eq(x,y) = \prod_i=1^num_var (x_i * r_i + (1-x_i)*(1-r_i))
-pub fn build_eq_x_r<F: PrimeField>(r: &[F]) -> Result<Arc<MultilinearPolynomial<F>>, NovaError> {
-  let evals = build_eq_x_r_vec(r)?;
+// pub fn build_eq_x_r<F: PrimeField>(r: &[F]) -> Result<Arc<MultilinearPolynomial<F>>, NovaError> {
+//   let evals = build_eq_x_r_vec(r)?;
 
-  let mle = MultilinearPolynomial::new(evals);
+//   let mle = MultilinearPolynomial::new(evals);
 
-  Ok(Arc::new(mle))
-}
+//   Ok(Arc::new(mle))
+// }
 
 /// This function build the eq(x, r) polynomial for any given r, and output the
 /// evaluation of eq(x, r) in its vector form.
@@ -369,64 +369,64 @@ pub fn build_eq_x_r<F: PrimeField>(r: &[F]) -> Result<Arc<MultilinearPolynomial<
 ///      eq(x,y) = \prod_i=1^num_var (x_i * y_i + (1-x_i)*(1-y_i))
 /// over r, which is
 ///      eq(x,y) = \prod_i=1^num_var (x_i * r_i + (1-x_i)*(1-r_i))
-pub fn build_eq_x_r_vec<F: PrimeField>(r: &[F]) -> Result<Vec<F>, NovaError> {
-  // we build eq(x,r) Fpom its evaluations
-  // we want to evaluate eq(x,r) over x \in {0, 1}^num_vars
-  // for example, with num_vars = 4, x is a binary vector of 4, then
-  //  0 0 0 0 -> (1-r0)   * (1-r1)    * (1-r2)    * (1-r3)
-  //  1 0 0 0 -> r0       * (1-r1)    * (1-r2)    * (1-r3)
-  //  0 1 0 0 -> (1-r0)   * r1        * (1-r2)    * (1-r3)
-  //  1 1 0 0 -> r0       * r1        * (1-r2)    * (1-r3)
-  //  ....
-  //  1 1 1 1 -> r0       * r1        * r2        * r3
-  // we will need 2^num_var evaluations
+// pub fn build_eq_x_r_vec<F: PrimeField>(r: &[F]) -> Result<Vec<F>, NovaError> {
+//   // we build eq(x,r) Fpom its evaluations
+//   // we want to evaluate eq(x,r) over x \in {0, 1}^num_vars
+//   // for example, with num_vars = 4, x is a binary vector of 4, then
+//   //  0 0 0 0 -> (1-r0)   * (1-r1)    * (1-r2)    * (1-r3)
+//   //  1 0 0 0 -> r0       * (1-r1)    * (1-r2)    * (1-r3)
+//   //  0 1 0 0 -> (1-r0)   * r1        * (1-r2)    * (1-r3)
+//   //  1 1 0 0 -> r0       * r1        * (1-r2)    * (1-r3)
+//   //  ....
+//   //  1 1 1 1 -> r0       * r1        * r2        * r3
+//   // we will need 2^num_var evaluations
 
-  let mut eval = Vec::new();
-  build_eq_x_r_helper(r, &mut eval)?;
+//   let mut eval = Vec::new();
+//   build_eq_x_r_helper(r, &mut eval)?;
 
-  Ok(eval)
-}
+//   Ok(eval)
+// }
 
 /// A helper function to build eq(x, r) recursively.
 /// This function takes `r.len()` steps, and for each step it requires a maximum
 /// `r.len()-1` multiplications.
-fn build_eq_x_r_helper<F: PrimeField>(r: &[F], buf: &mut Vec<F>) -> Result<(), NovaError> {
-  if r.is_empty() {
-    return Err(NovaError::VpArith);
-  } else if r.len() == 1 {
-    // initializing the buffer with [1-r_0, r_0]
-    buf.push(F::ONE - r[0]);
-    buf.push(r[0]);
-  } else {
-    build_eq_x_r_helper(&r[1..], buf)?;
+// fn build_eq_x_r_helper<F: PrimeField>(r: &[F], buf: &mut Vec<F>) -> Result<(), NovaError> {
+//   if r.is_empty() {
+//     return Err(NovaError::VpArith);
+//   } else if r.len() == 1 {
+//     // initializing the buffer with [1-r_0, r_0]
+//     buf.push(F::ONE - r[0]);
+//     buf.push(r[0]);
+//   } else {
+//     build_eq_x_r_helper(&r[1..], buf)?;
 
-    // suppose at the previous step we received [b_1, ..., b_k]
-    // for the current step we will need
-    // if x_0 = 0:   (1-r0) * [b_1, ..., b_k]
-    // if x_0 = 1:   r0 * [b_1, ..., b_k]
-    // let mut res = vec![];
-    // for &b_i in buf.iter() {
-    //     let tmp = r[0] * b_i;
-    //     res.push(b_i - tmp);
-    //     res.push(tmp);
-    // }
-    // *buf = res;
+//     // suppose at the previous step we received [b_1, ..., b_k]
+//     // for the current step we will need
+//     // if x_0 = 0:   (1-r0) * [b_1, ..., b_k]
+//     // if x_0 = 1:   r0 * [b_1, ..., b_k]
+//     // let mut res = vec![];
+//     // for &b_i in buf.iter() {
+//     //     let tmp = r[0] * b_i;
+//     //     res.push(b_i - tmp);
+//     //     res.push(tmp);
+//     // }
+//     // *buf = res;
 
-    let mut res = vec![F::ZERO; buf.len() << 1];
-    res.par_iter_mut().enumerate().for_each(|(i, val)| {
-      let bi = buf[i >> 1];
-      let tmp = r[0] * bi;
-      if i & 1 == 0 {
-        *val = bi - tmp;
-      } else {
-        *val = tmp;
-      }
-    });
-    *buf = res;
-  }
+//     let mut res = vec![F::ZERO; buf.len() << 1];
+//     res.par_iter_mut().enumerate().for_each(|(i, val)| {
+//       let bi = buf[i >> 1];
+//       let tmp = r[0] * bi;
+//       if i & 1 == 0 {
+//         *val = bi - tmp;
+//       } else {
+//         *val = tmp;
+//       }
+//     });
+//     *buf = res;
+//   }
 
-  Ok(())
-}
+//   Ok(())
+// }
 
 #[cfg(test)]
 mod test {
@@ -483,55 +483,55 @@ mod test {
     Ok(())
   }
 
-  #[test]
-  fn test_eq_xr() {
-    let mut rng = OsRng;
-    for nv in 4..10 {
-      let r: Vec<Fp> = (0..nv).map(|_| Fp::random(&mut rng)).collect();
-      let eq_x_r = build_eq_x_r(r.as_ref()).unwrap();
-      let eq_x_r2 = build_eq_x_r_for_test(r.as_ref());
-      assert_eq!(eq_x_r, eq_x_r2);
-    }
-  }
+  // #[test]
+  // fn test_eq_xr() {
+  //   let mut rng = OsRng;
+  //   for nv in 4..10 {
+  //     let r: Vec<Fp> = (0..nv).map(|_| Fp::random(&mut rng)).collect();
+  //     let eq_x_r = build_eq_x_r(r.as_ref()).unwrap();
+  //     let eq_x_r2 = build_eq_x_r_for_test(r.as_ref());
+  //     assert_eq!(eq_x_r, eq_x_r2);
+  //   }
+  // }
 
-  /// Naive method to build eq(x, r).
-  /// Only used for testing purpose.
+  ///// Naive method to build eq(x, r).
+  ///// Only used for testing purpose.
   // Evaluate
   //      eq(x,y) = \prod_i=1^num_var (x_i * y_i + (1-x_i)*(1-y_i))
   // over r, which is
   //      eq(x,y) = \prod_i=1^num_var (x_i * r_i + (1-x_i)*(1-r_i))
-  fn build_eq_x_r_for_test<F: PrimeField>(r: &[F]) -> Arc<MultilinearPolynomial<F>> {
-    // we build eq(x,r) Fpom its evaluations
-    // we want to evaluate eq(x,r) over x \in {0, 1}^num_vars
-    // for example, with num_vars = 4, x is a binary vector of 4, then
-    //  0 0 0 0 -> (1-r0)   * (1-r1)    * (1-r2)    * (1-r3)
-    //  1 0 0 0 -> r0       * (1-r1)    * (1-r2)    * (1-r3)
-    //  0 1 0 0 -> (1-r0)   * r1        * (1-r2)    * (1-r3)
-    //  1 1 0 0 -> r0       * r1        * (1-r2)    * (1-r3)
-    //  ....
-    //  1 1 1 1 -> r0       * r1        * r2        * r3
-    // we will need 2^num_var evaluations
+  // fn build_eq_x_r_for_test<F: PrimeField>(r: &[F]) -> Arc<MultilinearPolynomial<F>> {
+  //   // we build eq(x,r) Fpom its evaluations
+  //   // we want to evaluate eq(x,r) over x \in {0, 1}^num_vars
+  //   // for example, with num_vars = 4, x is a binary vector of 4, then
+  //   //  0 0 0 0 -> (1-r0)   * (1-r1)    * (1-r2)    * (1-r3)
+  //   //  1 0 0 0 -> r0       * (1-r1)    * (1-r2)    * (1-r3)
+  //   //  0 1 0 0 -> (1-r0)   * r1        * (1-r2)    * (1-r3)
+  //   //  1 1 0 0 -> r0       * r1        * (1-r2)    * (1-r3)
+  //   //  ....
+  //   //  1 1 1 1 -> r0       * r1        * r2        * r3
+  //   // we will need 2^num_var evaluations
 
-    // First, we build array for {1 - r_i}
-    let one_minus_r: Vec<F> = r.iter().map(|ri| F::ONE - ri).collect();
+  //   // First, we build array for {1 - r_i}
+  //   let one_minus_r: Vec<F> = r.iter().map(|ri| F::ONE - ri).collect();
 
-    let num_var = r.len();
-    let mut eval = vec![];
+  //   let num_var = r.len();
+  //   let mut eval = vec![];
 
-    for i in 0..1 << num_var {
-      let mut current_eval = F::ONE;
-      let bit_sequence = bit_decompose(i, num_var);
+  //   for i in 0..1 << num_var {
+  //     let mut current_eval = F::ONE;
+  //     let bit_sequence = bit_decompose(i, num_var);
 
-      for (&bit, (ri, one_minus_ri)) in bit_sequence.iter().zip(r.iter().zip(one_minus_r.iter())) {
-        current_eval *= if bit { *ri } else { *one_minus_ri };
-      }
-      eval.push(current_eval);
-    }
+  //     for (&bit, (ri, one_minus_ri)) in bit_sequence.iter().zip(r.iter().zip(one_minus_r.iter())) {
+  //       current_eval *= if bit { *ri } else { *one_minus_ri };
+  //     }
+  //     eval.push(current_eval);
+  //   }
 
-    let mle = MultilinearPolynomial::new(eval);
+  //   let mle = MultilinearPolynomial::new(eval);
 
-    Arc::new(mle)
-  }
+  //   Arc::new(mle)
+  // }
 }
 
 #[cfg(test)]
@@ -562,32 +562,32 @@ mod tests {
     );
   }
 
-  #[test]
-  fn test_eq_x_r_equality() {
-    let mut rng = OsRng;
+  // #[test]
+  // fn test_eq_x_r_equality() {
+  //   let mut rng = OsRng;
 
-    for num_vars in 1..=3 {
-      // Generate random inputs
-      let r: Vec<Fq> = (0..num_vars).map(|_| Fq::random(&mut rng)).collect();
+  //   for num_vars in 1..=3 {
+  //     // Generate random inputs
+  //     let r: Vec<Fq> = (0..num_vars).map(|_| Fq::random(&mut rng)).collect();
 
-      // Old version of eq_x_r using `virtual_poly.rs`
-      let eq_x_r_old = build_eq_x_r(&r).unwrap().clone();
+  //     // Old version of eq_x_r using `virtual_poly.rs`
+  //     let eq_x_r_old = build_eq_x_r(&r).unwrap().clone();
 
-      // New version of eq_x_r using `polynomial.rs`
-      let eq_polynomial = EqPolynomial::new(r.to_vec());
-      let evaluations = eq_polynomial.evals();
-      let multilinear_poly = MultilinearPolynomial::new(evaluations);
-      let eq_x_r_new = Arc::new(multilinear_poly);
+  //     // New version of eq_x_r using `polynomial.rs`
+  //     let eq_polynomial = EqPolynomial::new(r.to_vec());
+  //     let evaluations = eq_polynomial.evals();
+  //     let multilinear_poly = MultilinearPolynomial::new(evaluations);
+  //     let eq_x_r_new = Arc::new(multilinear_poly);
 
-      dbg!(eq_x_r_old.Z.clone());
-      dbg!(eq_x_r_new.Z.clone());
+  //     dbg!(eq_x_r_old.Z.clone());
+  //     dbg!(eq_x_r_new.Z.clone());
 
-      // Check equality of the results
-      assert_eq!(
-        eq_x_r_old.Z, eq_x_r_new.Z,
-        "eq_x_r_old.Z and eq_x_r.Z outputs are not equal for num_vars = {}",
-        num_vars
-      );
-    }
-  }
+  //     // Check equality of the results
+  //     assert_eq!(
+  //       eq_x_r_old.Z, eq_x_r_new.Z,
+  //       "eq_x_r_old.Z and eq_x_r.Z outputs are not equal for num_vars = {}",
+  //       num_vars
+  //     );
+  //   }
+  // }
 }

--- a/src/ccs/util/virtual_poly.rs
+++ b/src/ccs/util/virtual_poly.rs
@@ -294,17 +294,17 @@ impl<F: PrimeField> VirtualPolynomial<F> {
   }
 
   // XXX: Remove me, temp for debugging
-  // pub fn build_f_hat_old(&self, r: &[F]) -> Result<Self, NovaError> {
-  //   if self.aux_info.num_variables != r.len() {
-  //     return Err(NovaError::VpArith);
-  //   }
+  pub fn build_f_hat_old(&self, r: &[F]) -> Result<Self, NovaError> {
+    if self.aux_info.num_variables != r.len() {
+      return Err(NovaError::VpArith);
+    }
 
-  //   let eq_x_r_old = build_eq_x_r(r)?;
-  //   let mut res = self.clone();
-  //   res.mul_by_mle(eq_x_r_old, F::ONE)?;
+    let eq_x_r_old = build_eq_x_r(r)?;
+    let mut res = self.clone();
+    res.mul_by_mle(eq_x_r_old, F::ONE)?;
 
-  //   Ok(res)
-  // }
+    Ok(res)
+  }
 
   // Input poly f(x) and a random vector r, output
   //      \hat f(x) = \sum_{x_i \in eval_x} f(x_i) eq(x, r)
@@ -330,7 +330,7 @@ impl<F: PrimeField> VirtualPolynomial<F> {
     // See `build_eq_x_r_helper` helper below
 
     // Old version of eq_x_r using `virtual_poly.rs`
-    // let eq_x_r_old = build_eq_x_r(r)?;
+    let eq_x_r_old = build_eq_x_r(r)?;
 
     // New version of eq_x_r using `polynomial.rs`
     let eq_polynomial = EqPolynomial::new(r.to_vec());
@@ -338,7 +338,7 @@ impl<F: PrimeField> VirtualPolynomial<F> {
     let multilinear_poly = MultilinearPolynomial::new(evaluations);
     let eq_x_r_new = Arc::new(multilinear_poly);
 
-    // dbg!(eq_x_r_old.Z.clone());
+    dbg!(eq_x_r_old.Z.clone());
     dbg!(eq_x_r_new.Z.clone());
 
     let mut res = self.clone();
@@ -354,13 +354,13 @@ impl<F: PrimeField> VirtualPolynomial<F> {
 ///      eq(x,y) = \prod_i=1^num_var (x_i * y_i + (1-x_i)*(1-y_i))
 /// over r, which is
 ///      eq(x,y) = \prod_i=1^num_var (x_i * r_i + (1-x_i)*(1-r_i))
-// pub fn build_eq_x_r<F: PrimeField>(r: &[F]) -> Result<Arc<MultilinearPolynomial<F>>, NovaError> {
-//   let evals = build_eq_x_r_vec(r)?;
+pub fn build_eq_x_r<F: PrimeField>(r: &[F]) -> Result<Arc<MultilinearPolynomial<F>>, NovaError> {
+  let evals = build_eq_x_r_vec(r)?;
 
-//   let mle = MultilinearPolynomial::new(evals);
+  let mle = MultilinearPolynomial::new(evals);
 
-//   Ok(Arc::new(mle))
-// }
+  Ok(Arc::new(mle))
+}
 
 /// This function build the eq(x, r) polynomial for any given r, and output the
 /// evaluation of eq(x, r) in its vector form.
@@ -369,64 +369,64 @@ impl<F: PrimeField> VirtualPolynomial<F> {
 ///      eq(x,y) = \prod_i=1^num_var (x_i * y_i + (1-x_i)*(1-y_i))
 /// over r, which is
 ///      eq(x,y) = \prod_i=1^num_var (x_i * r_i + (1-x_i)*(1-r_i))
-// pub fn build_eq_x_r_vec<F: PrimeField>(r: &[F]) -> Result<Vec<F>, NovaError> {
-//   // we build eq(x,r) Fpom its evaluations
-//   // we want to evaluate eq(x,r) over x \in {0, 1}^num_vars
-//   // for example, with num_vars = 4, x is a binary vector of 4, then
-//   //  0 0 0 0 -> (1-r0)   * (1-r1)    * (1-r2)    * (1-r3)
-//   //  1 0 0 0 -> r0       * (1-r1)    * (1-r2)    * (1-r3)
-//   //  0 1 0 0 -> (1-r0)   * r1        * (1-r2)    * (1-r3)
-//   //  1 1 0 0 -> r0       * r1        * (1-r2)    * (1-r3)
-//   //  ....
-//   //  1 1 1 1 -> r0       * r1        * r2        * r3
-//   // we will need 2^num_var evaluations
+pub fn build_eq_x_r_vec<F: PrimeField>(r: &[F]) -> Result<Vec<F>, NovaError> {
+  // we build eq(x,r) Fpom its evaluations
+  // we want to evaluate eq(x,r) over x \in {0, 1}^num_vars
+  // for example, with num_vars = 4, x is a binary vector of 4, then
+  //  0 0 0 0 -> (1-r0)   * (1-r1)    * (1-r2)    * (1-r3)
+  //  1 0 0 0 -> r0       * (1-r1)    * (1-r2)    * (1-r3)
+  //  0 1 0 0 -> (1-r0)   * r1        * (1-r2)    * (1-r3)
+  //  1 1 0 0 -> r0       * r1        * (1-r2)    * (1-r3)
+  //  ....
+  //  1 1 1 1 -> r0       * r1        * r2        * r3
+  // we will need 2^num_var evaluations
 
-//   let mut eval = Vec::new();
-//   build_eq_x_r_helper(r, &mut eval)?;
+  let mut eval = Vec::new();
+  build_eq_x_r_helper(r, &mut eval)?;
 
-//   Ok(eval)
-// }
+  Ok(eval)
+}
 
 /// A helper function to build eq(x, r) recursively.
 /// This function takes `r.len()` steps, and for each step it requires a maximum
 /// `r.len()-1` multiplications.
-// fn build_eq_x_r_helper<F: PrimeField>(r: &[F], buf: &mut Vec<F>) -> Result<(), NovaError> {
-//   if r.is_empty() {
-//     return Err(NovaError::VpArith);
-//   } else if r.len() == 1 {
-//     // initializing the buffer with [1-r_0, r_0]
-//     buf.push(F::ONE - r[0]);
-//     buf.push(r[0]);
-//   } else {
-//     build_eq_x_r_helper(&r[1..], buf)?;
+fn build_eq_x_r_helper<F: PrimeField>(r: &[F], buf: &mut Vec<F>) -> Result<(), NovaError> {
+  if r.is_empty() {
+    return Err(NovaError::VpArith);
+  } else if r.len() == 1 {
+    // initializing the buffer with [1-r_0, r_0]
+    buf.push(F::ONE - r[0]);
+    buf.push(r[0]);
+  } else {
+    build_eq_x_r_helper(&r[1..], buf)?;
 
-//     // suppose at the previous step we received [b_1, ..., b_k]
-//     // for the current step we will need
-//     // if x_0 = 0:   (1-r0) * [b_1, ..., b_k]
-//     // if x_0 = 1:   r0 * [b_1, ..., b_k]
-//     // let mut res = vec![];
-//     // for &b_i in buf.iter() {
-//     //     let tmp = r[0] * b_i;
-//     //     res.push(b_i - tmp);
-//     //     res.push(tmp);
-//     // }
-//     // *buf = res;
+    // suppose at the previous step we received [b_1, ..., b_k]
+    // for the current step we will need
+    // if x_0 = 0:   (1-r0) * [b_1, ..., b_k]
+    // if x_0 = 1:   r0 * [b_1, ..., b_k]
+    // let mut res = vec![];
+    // for &b_i in buf.iter() {
+    //     let tmp = r[0] * b_i;
+    //     res.push(b_i - tmp);
+    //     res.push(tmp);
+    // }
+    // *buf = res;
 
-//     let mut res = vec![F::ZERO; buf.len() << 1];
-//     res.par_iter_mut().enumerate().for_each(|(i, val)| {
-//       let bi = buf[i >> 1];
-//       let tmp = r[0] * bi;
-//       if i & 1 == 0 {
-//         *val = bi - tmp;
-//       } else {
-//         *val = tmp;
-//       }
-//     });
-//     *buf = res;
-//   }
+    let mut res = vec![F::ZERO; buf.len() << 1];
+    res.par_iter_mut().enumerate().for_each(|(i, val)| {
+      let bi = buf[i >> 1];
+      let tmp = r[0] * bi;
+      if i & 1 == 0 {
+        *val = bi - tmp;
+      } else {
+        *val = tmp;
+      }
+    });
+    *buf = res;
+  }
 
-//   Ok(())
-// }
+  Ok(())
+}
 
 #[cfg(test)]
 mod test {
@@ -483,55 +483,55 @@ mod test {
     Ok(())
   }
 
-  // #[test]
-  // fn test_eq_xr() {
-  //   let mut rng = OsRng;
-  //   for nv in 4..10 {
-  //     let r: Vec<Fp> = (0..nv).map(|_| Fp::random(&mut rng)).collect();
-  //     let eq_x_r = build_eq_x_r(r.as_ref()).unwrap();
-  //     let eq_x_r2 = build_eq_x_r_for_test(r.as_ref());
-  //     assert_eq!(eq_x_r, eq_x_r2);
-  //   }
-  // }
+  #[test]
+  fn test_eq_xr() {
+    let mut rng = OsRng;
+    for nv in 4..10 {
+      let r: Vec<Fp> = (0..nv).map(|_| Fp::random(&mut rng)).collect();
+      let eq_x_r = build_eq_x_r(r.as_ref()).unwrap();
+      let eq_x_r2 = build_eq_x_r_for_test(r.as_ref());
+      assert_eq!(eq_x_r, eq_x_r2);
+    }
+  }
 
-  ///// Naive method to build eq(x, r).
-  ///// Only used for testing purpose.
+  /// Naive method to build eq(x, r).
+  /// Only used for testing purpose.
   // Evaluate
   //      eq(x,y) = \prod_i=1^num_var (x_i * y_i + (1-x_i)*(1-y_i))
   // over r, which is
   //      eq(x,y) = \prod_i=1^num_var (x_i * r_i + (1-x_i)*(1-r_i))
-  // fn build_eq_x_r_for_test<F: PrimeField>(r: &[F]) -> Arc<MultilinearPolynomial<F>> {
-  //   // we build eq(x,r) Fpom its evaluations
-  //   // we want to evaluate eq(x,r) over x \in {0, 1}^num_vars
-  //   // for example, with num_vars = 4, x is a binary vector of 4, then
-  //   //  0 0 0 0 -> (1-r0)   * (1-r1)    * (1-r2)    * (1-r3)
-  //   //  1 0 0 0 -> r0       * (1-r1)    * (1-r2)    * (1-r3)
-  //   //  0 1 0 0 -> (1-r0)   * r1        * (1-r2)    * (1-r3)
-  //   //  1 1 0 0 -> r0       * r1        * (1-r2)    * (1-r3)
-  //   //  ....
-  //   //  1 1 1 1 -> r0       * r1        * r2        * r3
-  //   // we will need 2^num_var evaluations
+  fn build_eq_x_r_for_test<F: PrimeField>(r: &[F]) -> Arc<MultilinearPolynomial<F>> {
+    // we build eq(x,r) Fpom its evaluations
+    // we want to evaluate eq(x,r) over x \in {0, 1}^num_vars
+    // for example, with num_vars = 4, x is a binary vector of 4, then
+    //  0 0 0 0 -> (1-r0)   * (1-r1)    * (1-r2)    * (1-r3)
+    //  1 0 0 0 -> r0       * (1-r1)    * (1-r2)    * (1-r3)
+    //  0 1 0 0 -> (1-r0)   * r1        * (1-r2)    * (1-r3)
+    //  1 1 0 0 -> r0       * r1        * (1-r2)    * (1-r3)
+    //  ....
+    //  1 1 1 1 -> r0       * r1        * r2        * r3
+    // we will need 2^num_var evaluations
 
-  //   // First, we build array for {1 - r_i}
-  //   let one_minus_r: Vec<F> = r.iter().map(|ri| F::ONE - ri).collect();
+    // First, we build array for {1 - r_i}
+    let one_minus_r: Vec<F> = r.iter().map(|ri| F::ONE - ri).collect();
 
-  //   let num_var = r.len();
-  //   let mut eval = vec![];
+    let num_var = r.len();
+    let mut eval = vec![];
 
-  //   for i in 0..1 << num_var {
-  //     let mut current_eval = F::ONE;
-  //     let bit_sequence = bit_decompose(i, num_var);
+    for i in 0..1 << num_var {
+      let mut current_eval = F::ONE;
+      let bit_sequence = bit_decompose(i, num_var);
 
-  //     for (&bit, (ri, one_minus_ri)) in bit_sequence.iter().zip(r.iter().zip(one_minus_r.iter())) {
-  //       current_eval *= if bit { *ri } else { *one_minus_ri };
-  //     }
-  //     eval.push(current_eval);
-  //   }
+      for (&bit, (ri, one_minus_ri)) in bit_sequence.iter().zip(r.iter().zip(one_minus_r.iter())) {
+        current_eval *= if bit { *ri } else { *one_minus_ri };
+      }
+      eval.push(current_eval);
+    }
 
-  //   let mle = MultilinearPolynomial::new(eval);
+    let mle = MultilinearPolynomial::new(eval);
 
-  //   Arc::new(mle)
-  // }
+    Arc::new(mle)
+  }
 }
 
 #[cfg(test)]
@@ -562,32 +562,32 @@ mod tests {
     );
   }
 
-  // #[test]
-  // fn test_eq_x_r_equality() {
-  //   let mut rng = OsRng;
+  #[test]
+  fn test_eq_x_r_equality() {
+    let mut rng = OsRng;
 
-  //   for num_vars in 1..=3 {
-  //     // Generate random inputs
-  //     let r: Vec<Fq> = (0..num_vars).map(|_| Fq::random(&mut rng)).collect();
+    for num_vars in 1..=3 {
+      // Generate random inputs
+      let r: Vec<Fq> = (0..num_vars).map(|_| Fq::random(&mut rng)).collect();
 
-  //     // Old version of eq_x_r using `virtual_poly.rs`
-  //     let eq_x_r_old = build_eq_x_r(&r).unwrap().clone();
+      // Old version of eq_x_r using `virtual_poly.rs`
+      let eq_x_r_old = build_eq_x_r(&r).unwrap().clone();
 
-  //     // New version of eq_x_r using `polynomial.rs`
-  //     let eq_polynomial = EqPolynomial::new(r.to_vec());
-  //     let evaluations = eq_polynomial.evals();
-  //     let multilinear_poly = MultilinearPolynomial::new(evaluations);
-  //     let eq_x_r_new = Arc::new(multilinear_poly);
+      // New version of eq_x_r using `polynomial.rs`
+      let eq_polynomial = EqPolynomial::new(r.to_vec());
+      let evaluations = eq_polynomial.evals();
+      let multilinear_poly = MultilinearPolynomial::new(evaluations);
+      let eq_x_r_new = Arc::new(multilinear_poly);
 
-  //     dbg!(eq_x_r_old.Z.clone());
-  //     dbg!(eq_x_r_new.Z.clone());
+      dbg!(eq_x_r_old.Z.clone());
+      dbg!(eq_x_r_new.Z.clone());
 
-  //     // Check equality of the results
-  //     assert_eq!(
-  //       eq_x_r_old.Z, eq_x_r_new.Z,
-  //       "eq_x_r_old.Z and eq_x_r.Z outputs are not equal for num_vars = {}",
-  //       num_vars
-  //     );
-  //   }
-  // }
+      // Check equality of the results
+      assert_eq!(
+        eq_x_r_old.Z, eq_x_r_new.Z,
+        "eq_x_r_old.Z and eq_x_r.Z outputs are not equal for num_vars = {}",
+        num_vars
+      );
+    }
+  }
 }

--- a/src/hypercube.rs
+++ b/src/hypercube.rs
@@ -57,21 +57,6 @@ impl<Scalar: PrimeField> Iterator for BooleanHypercube<Scalar> {
       Some(point)
     }
   }
-
-  // fn next(&mut self) -> Option<Self::Item> {
-  //   if self.current >= self.max {
-  //     None
-  //   } else {
-  //     let bits = bit_decompose(self.current, self.n_vars);
-  //     let point: Vec<Scalar> = bits
-  //       .iter()
-  //       .map(|&bit| Scalar::from(bit as u64))
-  //       .rev()
-  //       .collect();
-  //     self.current += 1;
-  //     Some(point)
-  //   }
-  // }
 }
 
 /// Decompose an integer into a binary vector in little endian.

--- a/src/hypercube.rs
+++ b/src/hypercube.rs
@@ -113,7 +113,11 @@ mod tests {
       vec![F::ONE, F::ONE, F::ONE],
     ];
 
-    for i in 0..hypercube.max as usize {
+    for (i, _) in expected_outputs
+      .iter()
+      .enumerate()
+      .take(hypercube.max as usize)
+    {
       assert_eq!(hypercube.evaluate_at_big(i), expected_outputs[i]);
     }
   }
@@ -152,7 +156,11 @@ mod tests {
       vec![F::ONE, F::ONE, F::ONE],
     ];
 
-    for i in 0..hypercube.max as usize {
+    for (i, _) in expected_outputs
+      .iter()
+      .enumerate()
+      .take(hypercube.max as usize)
+    {
       assert_eq!(hypercube.evaluate_at_little(i), expected_outputs[i]);
     }
   }

--- a/src/hypercube.rs
+++ b/src/hypercube.rs
@@ -25,10 +25,22 @@ impl<F: PrimeField> BooleanHypercube<F> {
   }
 
   /// returns the entry at given i (which is the big-endian bit representation of i)
-  pub(crate) fn evaluate_at(&self, i: usize) -> Vec<F> {
+  pub(crate) fn evaluate_at_big(&self, i: usize) -> Vec<F> {
+    assert!(i < self.max as usize);
+    let bits = bit_decompose((i) as u64, self.n_vars);
+    bits.iter().map(|&x| F::from(x as u64)).collect()
+  }
+
+  /// returns the entry at given i (which is the little-endian bit representation of i)
+  pub(crate) fn evaluate_at_little(&self, i: usize) -> Vec<F> {
     assert!(i < self.max as usize);
     let bits = bit_decompose((i) as u64, self.n_vars);
     bits.iter().map(|&x| F::from(x as u64)).rev().collect()
+  }
+
+  pub(crate) fn evaluate_at(&self, i: usize) -> Vec<F> {
+    // This is what we are currently using
+    self.evaluate_at_little(i)
   }
 }
 
@@ -45,6 +57,21 @@ impl<Scalar: PrimeField> Iterator for BooleanHypercube<Scalar> {
       Some(point)
     }
   }
+
+  // fn next(&mut self) -> Option<Self::Item> {
+  //   if self.current >= self.max {
+  //     None
+  //   } else {
+  //     let bits = bit_decompose(self.current, self.n_vars);
+  //     let point: Vec<Scalar> = bits
+  //       .iter()
+  //       .map(|&bit| Scalar::from(bit as u64))
+  //       .rev()
+  //       .collect();
+  //     self.current += 1;
+  //     Some(point)
+  //   }
+  // }
 }
 
 /// Decompose an integer into a binary vector in little endian.
@@ -72,8 +99,80 @@ mod tests {
     assert_eq!(poly.evaluate_at(point), vec![F::ONE, F::ONE, F::ONE]);
   }
 
+  fn test_big_endian_eval_with<F: PrimeField>() {
+    let mut hypercube = BooleanHypercube::<F>::new(3);
+
+    let expected_outputs = vec![
+      vec![F::ZERO, F::ZERO, F::ZERO],
+      vec![F::ONE, F::ZERO, F::ZERO],
+      vec![F::ZERO, F::ONE, F::ZERO],
+      vec![F::ONE, F::ONE, F::ZERO],
+      vec![F::ZERO, F::ZERO, F::ONE],
+      vec![F::ONE, F::ZERO, F::ONE],
+      vec![F::ZERO, F::ONE, F::ONE],
+      vec![F::ONE, F::ONE, F::ONE],
+    ];
+
+    for i in 0..hypercube.max as usize {
+      assert_eq!(hypercube.evaluate_at_big(i), expected_outputs[i]);
+    }
+  }
+
+  fn test_big_endian_next_with<F: PrimeField>() {
+    let mut hypercube = BooleanHypercube::<F>::new(3);
+
+    let expected_outputs = vec![
+      vec![F::ZERO, F::ZERO, F::ZERO],
+      vec![F::ONE, F::ZERO, F::ZERO],
+      vec![F::ZERO, F::ONE, F::ZERO],
+      vec![F::ONE, F::ONE, F::ZERO],
+      vec![F::ZERO, F::ZERO, F::ONE],
+      vec![F::ONE, F::ZERO, F::ONE],
+      vec![F::ZERO, F::ONE, F::ONE],
+      vec![F::ONE, F::ONE, F::ONE],
+    ];
+
+    for expected_output in expected_outputs {
+      let actual_output = hypercube.next().unwrap();
+      assert_eq!(actual_output, expected_output);
+    }
+  }
+
+  fn test_little_endian_eval_with<F: PrimeField>() {
+    let mut hypercube = BooleanHypercube::<F>::new(3);
+
+    let expected_outputs = vec![
+      vec![F::ZERO, F::ZERO, F::ZERO],
+      vec![F::ZERO, F::ZERO, F::ONE],
+      vec![F::ZERO, F::ONE, F::ZERO],
+      vec![F::ZERO, F::ONE, F::ONE],
+      vec![F::ONE, F::ZERO, F::ZERO],
+      vec![F::ONE, F::ZERO, F::ONE],
+      vec![F::ONE, F::ONE, F::ZERO],
+      vec![F::ONE, F::ONE, F::ONE],
+    ];
+
+    for i in 0..hypercube.max as usize {
+      assert_eq!(hypercube.evaluate_at_little(i), expected_outputs[i]);
+    }
+  }
+
   #[test]
   fn test_evaluate() {
     test_evaluate_with::<Fq>();
+  }
+  #[test]
+  fn test_big_endian_eval() {
+    test_big_endian_eval_with::<Fq>();
+  }
+
+  #[test]
+  fn test_big_endian_next() {
+    test_big_endian_next_with::<Fq>();
+  }
+
+  #[test]
+  fn test_little_endian_eval() {
+    test_little_endian_eval_with::<Fq>();
   }
 }

--- a/src/spartan/mod.rs
+++ b/src/spartan/mod.rs
@@ -5,7 +5,7 @@
 //! We also provide direct.rs that allows proving a step circuit directly with either of the two SNARKs.
 pub mod direct;
 pub(crate) mod math;
-pub(crate) mod polynomial;
+pub mod polynomial;
 pub mod ppsnark;
 pub mod snark;
 mod sumcheck;

--- a/src/spartan/polynomial.rs
+++ b/src/spartan/polynomial.rs
@@ -84,6 +84,9 @@ pub struct MultilinearPolynomial<Scalar: PrimeField> {
 }
 
 impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
+  /// Creates a new MultilinearPolynomial from the given evaluations.
+  ///
+  /// The number of evaluations must be a power of two.
   pub fn new(Z: Vec<Scalar>) -> Self {
     assert_eq!(Z.len(), (2_usize).pow((Z.len() as f64).log2() as u32));
     MultilinearPolynomial {
@@ -92,15 +95,19 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
     }
   }
 
+  /// Returns the number of variables in the multilinear polynomial
   pub fn get_num_vars(&self) -> usize {
     self.num_vars
   }
 
+  /// Returns the total number of evaluations.
   pub fn len(&self) -> usize {
     self.Z.len()
   }
 
-  // NOTE: this is equivalent to Espresso/hyperplonk's 'fix_last_variables' mehthod
+  /// Bounds the polynomial's top variable using the given scalar.
+  ///
+  /// This operation modifies the polynomial in-place.
   pub fn bound_poly_var_top(&mut self, r: &Scalar) {
     let n = self.len() / 2;
 
@@ -118,7 +125,10 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
     self.num_vars -= 1;
   }
 
-  // returns Z(r) in O(n) time
+  /// Evaluates the polynomial at the given point.
+  /// Returns Z(r) in O(n) time.
+  ///
+  /// The point must have a value for each variable.
   pub fn evaluate(&self, r: &[Scalar]) -> Scalar {
     // r must have a value for each variable
     assert_eq!(r.len(), self.get_num_vars());
@@ -131,6 +141,7 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
       .reduce(|| Scalar::ZERO, |x, y| x + y)
   }
 
+  /// Evaluates the polynomial with the given evaluations and point.
   pub fn evaluate_with(Z: &[Scalar], r: &[Scalar]) -> Scalar {
     EqPolynomial::new(r.to_vec())
       .evals()
@@ -140,7 +151,7 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
       .reduce(|| Scalar::ZERO, |x, y| x + y)
   }
 
-  // Multiplies `self` by a scalar.
+  /// Multiplies the polynomial by a scalar.
   #[allow(unused)]
   pub fn scalar_mul(&self, scalar: &Scalar) -> Self {
     let mut new_poly = self.clone();
@@ -304,7 +315,7 @@ mod tests {
   }
 
   fn test_sparse_polynomial_with<F: PrimeField>() {
-    // Let the polynomial has 3 variables, p(x_1, x_2, x_3) = (x_1 + x_2) * x_3
+    // Let the polynomial have 3 variables, p(x_1, x_2, x_3) = (x_1 + x_2) * x_3
     // Evaluations of the polynomial at boolean cube are [0, 0, 0, 1, 0, 1, 0, 2].
 
     let TWO = F::from(2);

--- a/src/spartan/polynomial.rs
+++ b/src/spartan/polynomial.rs
@@ -46,7 +46,7 @@ impl<Scalar: PrimeField> EqPolynomial<Scalar> {
   /// Evaluates the `EqPolynomial` at all the `2^|r|` points in its domain.
   ///
   /// Returns a vector of Scalars, each corresponding to the polynomial evaluation at a specific point.
-  pub fn evals_current(&self) -> Vec<Scalar> {
+  pub fn evals(&self) -> Vec<Scalar> {
     let ell = self.r.len();
     let mut evals: Vec<Scalar> = vec![Scalar::ZERO; (2_usize).pow(ell as u32)];
     let mut size = 1;
@@ -68,48 +68,6 @@ impl<Scalar: PrimeField> EqPolynomial<Scalar> {
     }
 
     evals
-  }
-
-  // XXX: Just temporary for debugging
-  // `cargo test test_eq_x_r_equality` passes with this, but not `compute_g`
-
-  /// Evaluates the `EqPolynomial` at all the `2^|r|` points in its domain.
-  ///
-  /// Returns a vector of Scalars, each corresponding to the polynomial evaluation at a specific point.
-  pub fn evals(&self) -> Vec<Scalar> {
-    let ell = self.r.len();
-    let n = (2_usize).pow(ell as u32);
-    let mut evals: Vec<Scalar> = vec![Scalar::ZERO; n];
-    let mut res: Vec<Scalar> = vec![Scalar::ZERO; n];
-    let mut size = 1;
-    evals[0] = Scalar::ONE;
-
-    for r in self.r.iter().rev() {
-      let (evals_left, evals_right) = evals.split_at_mut(size);
-      let (evals_right, _) = evals_right.split_at_mut(size);
-
-      evals_left
-        .par_iter_mut()
-        .zip(evals_right.par_iter_mut())
-        .for_each(|(x, y)| {
-          *y = *x * r;
-          *x -= &*y;
-        });
-
-      size *= 2;
-    }
-
-    dbg!(evals.clone());
-
-    for i in 0..n {
-      let old_idx = i;
-      let new_idx = old_idx.reverse_bits() >> (std::mem::size_of::<usize>() * 8 - ell);
-      res[new_idx] = evals[old_idx].clone();
-    }
-
-    dbg!(res.clone());
-
-    res
   }
 }
 

--- a/src/spartan/polynomial.rs
+++ b/src/spartan/polynomial.rs
@@ -114,6 +114,13 @@ impl<Scalar: PrimeField> MultilinearPolynomial<Scalar> {
     self.Z.len()
   }
 
+  /// Checks if the multilinear polynomial is empty.
+  ///
+  /// This method returns true if the polynomial has no evaluations, and false otherwise.
+  pub fn is_empty(&self) -> bool {
+    self.Z.is_empty()
+  }
+
   /// Bounds the polynomial's top variable using the given scalar.
   ///
   /// This operation modifies the polynomial in-place.

--- a/src/spartan/polynomial.rs
+++ b/src/spartan/polynomial.rs
@@ -7,28 +7,35 @@ use std::ops::{Add, Mul};
 
 use crate::spartan::math::Math;
 
-/// The multilinear extension polynomial, denoted as $\tilde{eq}$, is defined as follows:
+/// Represents the multilinear extension polynomial (MLE) of the equality polynomial $eq(x,e)$, denoted as $\tilde{eq}(x, e)$.
 ///
+/// The polynomial is defined by the formula:
 /// $$
 /// \tilde{eq}(x, e) = \prod_{i=0}^m(e_i * x_i + (1 - e_i) * (1 - x_i))
 /// $$
 ///
-/// This polynomial evaluates to 1 only when each component $x_i$ is equal to its corresponding component $e_i$.
-/// Otherwise, it evaluates to 0.
+/// Each element in the vector `r` corresponds to a component $e_i$, representing a bit from the binary representation of an input value $e$.
+/// This polynomial evaluates to 1 if every component $x_i$ equals its corresponding $e_i$, and 0 otherwise.
 ///
-/// The vector r contains all the values of e_i, where e_i represents the individual bits of a binary representation of e.
-/// For example, let's consider e = 6, which in binary is 0b110. In this case, the vector r would be [1, 1, 0].
+/// For instance, for e = 6 (with a binary representation of 0b110), the vector r would be [1, 1, 0].
 pub struct EqPolynomial<Scalar: PrimeField> {
   r: Vec<Scalar>,
 }
 
 impl<Scalar: PrimeField> EqPolynomial<Scalar> {
-  /// Creates a new polynomial from its succinct specification
+  /// Creates a new `EqPolynomial` from a vector of Scalars `r`.
+  ///
+  /// Each Scalar in `r` corresponds to a bit from the binary representation of an input value `e`.
   pub fn new(r: Vec<Scalar>) -> Self {
     EqPolynomial { r }
   }
 
-  /// Evaluates the polynomial at the specified point
+  /// Evaluates the `EqPolynomial` at a given point `rx`.
+  ///
+  /// This function computes the value of the polynomial at the point specified by `rx`.
+  /// It expects `rx` to have the same length as the internal vector `r`.
+  ///
+  /// Panics if `rx` and `r` have different lengths.
   pub fn evaluate(&self, rx: &[Scalar]) -> Scalar {
     assert_eq!(self.r.len(), rx.len());
     (0..rx.len())
@@ -36,7 +43,9 @@ impl<Scalar: PrimeField> EqPolynomial<Scalar> {
       .fold(Scalar::ONE, |acc, item| acc * item)
   }
 
-  /// Evaluates the polynomial at all the `2^|r|` points, ranging from 0 to `2^|r| - 1`.
+  /// Evaluates the `EqPolynomial` at all the `2^|r|` points in its domain.
+  ///
+  /// Returns a vector of Scalars, each corresponding to the polynomial evaluation at a specific point.
   pub fn evals(&self) -> Vec<Scalar> {
     let ell = self.r.len();
     let mut evals: Vec<Scalar> = vec![Scalar::ZERO; (2_usize).pow(ell as u32)];
@@ -61,7 +70,7 @@ impl<Scalar: PrimeField> EqPolynomial<Scalar> {
   }
 }
 
-/// A multilinear extension of a polynomial $Z(\cdot)$, donate it as $\tilde{Z}(x_1, ..., x_m)$
+/// A multilinear extension of a polynomial $Z(\cdot)$, denote it as $\tilde{Z}(x_1, ..., x_m)$
 /// where the degree of each variable is at most one.
 ///
 /// This is the dense representation of a multilinear poynomial.

--- a/src/spartan/polynomial.rs
+++ b/src/spartan/polynomial.rs
@@ -1,4 +1,9 @@
-//! This module defines basic types related to polynomials
+//! This module provides foundational types and functions for manipulating multilinear polynomials in the context of cryptographic computations.
+//!
+//! Main components:
+//! - `EqPolynomial`: Represents multilinear extension of equality polynomials, evaluated based on binary input values.
+//! - `MultilinearPolynomial`: Dense representation of multilinear polynomials, represented by evaluations over all possible binary inputs.
+//! - `SparsePolynomial`: Efficient representation of sparse multilinear polynomials, storing only non-zero evaluations.
 use core::ops::Index;
 use ff::PrimeField;
 use rayon::prelude::*;
@@ -70,8 +75,6 @@ impl<Scalar: PrimeField> EqPolynomial<Scalar> {
     evals
   }
 }
-
-// TODO Update these docs too
 
 /// A multilinear extension of a polynomial $Z(\cdot)$, denote it as $\tilde{Z}(x_1, ..., x_m)$
 /// where the degree of each variable is at most one.

--- a/src/spartan/polynomial.rs
+++ b/src/spartan/polynomial.rs
@@ -46,7 +46,7 @@ impl<Scalar: PrimeField> EqPolynomial<Scalar> {
   /// Evaluates the `EqPolynomial` at all the `2^|r|` points in its domain.
   ///
   /// Returns a vector of Scalars, each corresponding to the polynomial evaluation at a specific point.
-  pub fn evals(&self) -> Vec<Scalar> {
+  pub fn evals_current(&self) -> Vec<Scalar> {
     let ell = self.r.len();
     let mut evals: Vec<Scalar> = vec![Scalar::ZERO; (2_usize).pow(ell as u32)];
     let mut size = 1;
@@ -68,6 +68,48 @@ impl<Scalar: PrimeField> EqPolynomial<Scalar> {
     }
 
     evals
+  }
+
+  // XXX: Just temporary for debugging
+  // `cargo test test_eq_x_r_equality` passes with this, but not `compute_g`
+
+  /// Evaluates the `EqPolynomial` at all the `2^|r|` points in its domain.
+  ///
+  /// Returns a vector of Scalars, each corresponding to the polynomial evaluation at a specific point.
+  pub fn evals(&self) -> Vec<Scalar> {
+    let ell = self.r.len();
+    let n = (2_usize).pow(ell as u32);
+    let mut evals: Vec<Scalar> = vec![Scalar::ZERO; n];
+    let mut res: Vec<Scalar> = vec![Scalar::ZERO; n];
+    let mut size = 1;
+    evals[0] = Scalar::ONE;
+
+    for r in self.r.iter().rev() {
+      let (evals_left, evals_right) = evals.split_at_mut(size);
+      let (evals_right, _) = evals_right.split_at_mut(size);
+
+      evals_left
+        .par_iter_mut()
+        .zip(evals_right.par_iter_mut())
+        .for_each(|(x, y)| {
+          *y = *x * r;
+          *x -= &*y;
+        });
+
+      size *= 2;
+    }
+
+    dbg!(evals.clone());
+
+    for i in 0..n {
+      let old_idx = i;
+      let new_idx = old_idx.reverse_bits() >> (std::mem::size_of::<usize>() * 8 - ell);
+      res[new_idx] = evals[old_idx].clone();
+    }
+
+    dbg!(res.clone());
+
+    res
   }
 }
 

--- a/src/spartan/polynomial.rs
+++ b/src/spartan/polynomial.rs
@@ -18,7 +18,7 @@ use crate::spartan::math::Math;
 ///
 /// The vector r contains all the values of e_i, where e_i represents the individual bits of a binary representation of e.
 /// For example, let's consider e = 6, which in binary is 0b110. In this case, the vector r would be [1, 1, 0].
-pub(crate) struct EqPolynomial<Scalar: PrimeField> {
+pub struct EqPolynomial<Scalar: PrimeField> {
   r: Vec<Scalar>,
 }
 

--- a/src/spartan/polynomial.rs
+++ b/src/spartan/polynomial.rs
@@ -66,9 +66,12 @@ impl<Scalar: PrimeField> EqPolynomial<Scalar> {
 
       size *= 2;
     }
+
     evals
   }
 }
+
+// TODO Update these docs too
 
 /// A multilinear extension of a polynomial $Z(\cdot)$, denote it as $\tilde{Z}(x_1, ..., x_m)$
 /// where the degree of each variable is at most one.


### PR DESCRIPTION
- Remove custom eq_poly and use EqPolynomial instead
- Update polynomial docs
- Ensures order of evaluation is consistent between for VirtualPoly and EqPolynomial
- Remove old build_eq_x_r_vec and build_eq_x_r_helper
- Tests around boolean hypercube and other introduced functions to make endianness explicit etc

Addresses https://github.com/privacy-scaling-explorations/Nova/issues/19